### PR TITLE
Feature: QuickView

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default tseslint.config(
   },
   {
     rules: {
+      '@typescript-eslint/no-var-requires': 'off',
       '@typescript-eslint/prefer-as-const': 'off',
       '@typescript-eslint/no-unsafe-declaration-merging': 'off',
       '@typescript-eslint/explicit-function-return-type': ['error', { 'allowExpressions': true }],

--- a/scripts/template.md
+++ b/scripts/template.md
@@ -76,6 +76,18 @@ module.exports = () => {
 };
 ```
 
+# Quick View
+QuickView is used to quickly display your assets with as few lines of code as possible. Simply call the static ``QuickView()`` method (with your data-uri as a parameter) to create an instance of DIVE with your asset to use in further code.
+```ts
+import { DIVE } from '@shopware-ag/dive';
+
+const dive = DIVE.QuickView('your/asset/uri.glb'); // <-- call QuickView()
+
+const myCanvasWrapper = document.createElement('div');
+myCanvasWrapper.appendChild(dive.Canvas);
+
+```
+
 # Getting started
 Import:
 ```ts

--- a/scripts/template.md
+++ b/scripts/template.md
@@ -170,28 +170,29 @@ unsubscribe(); // <-- execute unsubscribe callback when done
 
 In the following you find a list of all available actions to perform on DIVECommunication class via `com.PerformAction()`.
 
-| Action                                                                         | Description
-|:-------------------------------------------------------------------------------| :---
-| [GET_ALL_SCENE_DATA](./src/com/actions/scene/getallscenedata.ts)               | Return all scene data that is currently set
-| [GET_ALL_OBJECTS](./src/com/actions/object/getallobjects.ts)                   | Return a map of all objects
-| [GET_OBJECTS](./src/com/actions/object/getobjects.ts)                          | Return an array of all objects with given ids
-| [PLACE_ON_FLOOR](./src/com/actions/object/model/placeonfloor.ts)               | Set a model onto to the floor
-| [ADD_OBJECT](./src/com/actions/object/addobject.ts)                            | Add an object to the scene
-| [UPDATE_OBJECT](./src/com/actions/object/updateobject.ts)                      | Update an existing object
-| [DELETE_OBJECT](./src/com/actions/object/deleteobject.ts)                      | Delete an existing object
-| [SELECT_OBJECT](./src/com/actions/object/selectobject.ts)                      | Select an existing object in the scene
-| [DESELECT_OBJECT](./src/com/actions/object/deselectobject.ts)                  | Deselect an existing object in the scene
-| [SET_BACKGROUND](./src/com/actions/scene/setbackground.ts)                     | Set a background color
-| [DROP_IT](./src/com/actions/object/model/dropit.ts)                            | Places the model onto the next underlying object's bounding box
-| [PLACE_ON_FLOOR](./src/com/actions/object/model/placeonfloor.ts)               | Places the model onto the floor (zero plane)
-| [SET_CAMERA_TRANSFORM](./src/com/actions/camera/setcameratransform.ts)         | Set camera transformation (w/o animation, used to initially set up camera)
-| [GET_CAMERA_TRANSFORM](./src/com/actions/camera/getcameratransform.ts)         | Return currenty camera transformation
-| [MOVE_CAMERA](./src/com/actions/camera/movecamera.ts)                          | Move camera to a specific position or the position of a previously defined POV (with an animation)
-| [RESET_CAMERA](./src/com/actions/camera/resetcamera.ts)                        | Reset camera to original position after MOVE_CAMERA was performed
-| [SET_CAMERA_LAYER](./src/com/actions/camera/setcameralayer.ts)                 | Set camera layer to switch between live view and editor view
-| [ZOOM_CAMERA](./src/com/actions/camera/zoomcamera.ts)                          | Zoom in or out
-| [SET_GIZMO_MODE](./src/com/actions/toolbox/select/setgizmomode.ts)             | Set gizmo mode
-| [SET_GIZMO_VISIBILITY](./src/com/actions/toolbox/select/setgizmovisibility.ts) | Set gizmo visibility
-| [MODEL_LOADED](./src/com/actions/object/model/modelloaded.ts)                  | Is performed when a model file is completely loaded
-| [UPDATE_SCENE](./src/com/actions/scene/updatescene.ts)                         | Update scene data
-| [GENERATE_MEDIA](./src/com/actions/media/generatemedia.ts)                     | Generate a screenshot with the specified parameters
+| Action                                                                                | Description
+|:--------------------------------------------------------------------------------------| :---
+| [GET_ALL_SCENE_DATA](./src/com/actions/scene/getallscenedata.ts)                      | Return all scene data that is currently set
+| [GET_ALL_OBJECTS](./src/com/actions/object/getallobjects.ts)                          | Return a map of all objects
+| [GET_OBJECTS](./src/com/actions/object/getobjects.ts)                                 | Return an array of all objects with given ids
+| [PLACE_ON_FLOOR](./src/com/actions/object/model/placeonfloor.ts)                      | Set a model onto to the floor
+| [ADD_OBJECT](./src/com/actions/object/addobject.ts)                                   | Add an object to the scene
+| [UPDATE_OBJECT](./src/com/actions/object/updateobject.ts)                             | Update an existing object
+| [DELETE_OBJECT](./src/com/actions/object/deleteobject.ts)                             | Delete an existing object
+| [SELECT_OBJECT](./src/com/actions/object/selectobject.ts)                             | Select an existing object in the scene
+| [DESELECT_OBJECT](./src/com/actions/object/deselectobject.ts)                         | Deselect an existing object in the scene
+| [SET_BACKGROUND](./src/com/actions/scene/setbackground.ts)                            | Set a background color
+| [DROP_IT](./src/com/actions/object/model/dropit.ts)                                   | Places the model onto the next underlying object's bounding box
+| [PLACE_ON_FLOOR](./src/com/actions/object/model/placeonfloor.ts)                      | Places the model onto the floor (zero plane)
+| [SET_CAMERA_TRANSFORM](./src/com/actions/camera/setcameratransform.ts)                | Set camera transformation (w/o animation, used to initially set up camera)
+| [GET_CAMERA_TRANSFORM](./src/com/actions/camera/getcameratransform.ts)                | Return currenty camera transformation
+| [MOVE_CAMERA](./src/com/actions/camera/movecamera.ts)                                 | Move camera to a specific position or the position of a previously defined POV (with an animation)
+| [RESET_CAMERA](./src/com/actions/camera/resetcamera.ts)                               | Reset camera to original position after MOVE_CAMERA was performed
+| [COMPUTE_ENCOMPASSING_VIEW](./src/com/actions/camera/computeencompassingview.ts),     | Calculates the camera position and target to view the whole scene
+| [SET_CAMERA_LAYER](./src/com/actions/camera/setcameralayer.ts)                        | Set camera layer to switch between live view and editor view
+| [ZOOM_CAMERA](./src/com/actions/camera/zoomcamera.ts)                                 | Zoom in or out
+| [SET_GIZMO_MODE](./src/com/actions/toolbox/select/setgizmomode.ts)                    | Set gizmo mode
+| [SET_GIZMO_VISIBILITY](./src/com/actions/toolbox/select/setgizmovisibility.ts)        | Set gizmo visibility
+| [MODEL_LOADED](./src/com/actions/object/model/modelloaded.ts)                         | Is performed when a model file is completely loaded
+| [UPDATE_SCENE](./src/com/actions/scene/updatescene.ts)                                | Update scene data
+| [GENERATE_MEDIA](./src/com/actions/media/generatemedia.ts)                            | Generate a screenshot with the specified parameters

--- a/src/__test__/DIVE.test.ts
+++ b/src/__test__/DIVE.test.ts
@@ -38,7 +38,10 @@ jest.mock('three/src/math/MathUtils', () => {
 
 jest.mock('../com/Communication.ts', () => {
     return jest.fn(function () {
-        this.PerformAction = jest.fn();
+        this.PerformAction = jest.fn().mockReturnValue({
+            position: { x: 0, y: 0, z: 0 },
+            target: { x: 0, y: 0, z: 0 },
+        });
         this.Subscribe = jest.fn((action: string, callback: (data: { id: string }) => void) => {
             callback({ id: 'incorrect id' });
             callback({ id: 'test_uuid' });
@@ -50,31 +53,33 @@ jest.mock('../com/Communication.ts', () => {
 });
 
 jest.mock('../renderer/Renderer.ts', () => {
-    return jest.fn(function () {
-        this.domElement = {
-            clientWidth: 800,
-            clientHeight: 600,
-            style: {
-                position: 'absolute',
-            },
-        };
-        this.domElement.parentElement = this.domElement;
-        this.AddPreRenderCallback = (callback: () => void) => {
-            callback();
-        };
-        this.RemovePreRenderCallback = jest.fn();
-        this.AddPostRenderCallback = (callback: () => void) => {
-            callback();
-        };
-        this.getViewport = jest.fn();
-        this.setViewport = jest.fn();
-        this.autoClear = false;
-        this.render = jest.fn();
-        this.StartRenderer = jest.fn();
-        this.OnResize = jest.fn();
-        this.Dispose = jest.fn();
-        return this;
-    });
+    return {
+        DIVERenderer: jest.fn(function () {
+            this.domElement = {
+                clientWidth: 800,
+                clientHeight: 600,
+                style: {
+                    position: 'absolute',
+                },
+            };
+            this.domElement.parentElement = this.domElement;
+            this.AddPreRenderCallback = (callback: () => void) => {
+                callback();
+            };
+            this.RemovePreRenderCallback = jest.fn();
+            this.AddPostRenderCallback = (callback: () => void) => {
+                callback();
+            };
+            this.getViewport = jest.fn();
+            this.setViewport = jest.fn();
+            this.autoClear = false;
+            this.render = jest.fn();
+            this.StartRenderer = jest.fn();
+            this.OnResize = jest.fn();
+            this.Dispose = jest.fn();
+            return this;
+        }),
+    }
 });
 
 jest.mock('../scene/Scene.ts', () => {

--- a/src/__test__/DIVE.test.ts
+++ b/src/__test__/DIVE.test.ts
@@ -155,6 +155,7 @@ jest.mock('../toolbox/Toolbox.ts', () => {
         this.userData = {
             id: undefined,
         }
+        this.Dispose = jest.fn();
         this.removeFromParent = jest.fn();
         return this;
     });

--- a/src/__test__/DIVE.test.ts
+++ b/src/__test__/DIVE.test.ts
@@ -36,6 +36,18 @@ jest.mock('three/src/math/MathUtils', () => {
     }
 });
 
+jest.mock('../com/Communication.ts', () => {
+    return jest.fn(function () {
+        this.PerformAction = jest.fn();
+        this.Subscribe = jest.fn((action: string, callback: (data: { id: string }) => void) => {
+            callback({ id: 'incorrect id' });
+            callback({ id: 'test_uuid' });
+        });
+
+        return this;
+    });
+});
+
 jest.mock('../renderer/Renderer.ts', () => {
     return jest.fn(function () {
         this.domElement = {
@@ -158,11 +170,17 @@ jest.mock('../axiscamera/AxisCamera.ts', () => {
         }
         this.removeFromParent = jest.fn();
         this.SetFromCameraMatrix = jest.fn();
+        this.Dispose = jest.fn();
         return this;
     });
 });
 
 describe('dive/DIVE', () => {
+    it('should QuickView', () => {
+        const dive = DIVE.QuickView('test_uri');
+        expect(dive).toBeDefined();
+    });
+
     it('should instantiate', () => {
         const dive = new DIVE();
         expect(dive).toBeDefined();
@@ -174,6 +192,7 @@ describe('dive/DIVE', () => {
     it('should instantiate with settings', () => {
         const settings = {
             autoResize: false,
+            displayAxes: true,
             renderer: {
                 antialias: false,
                 alpha: false,
@@ -215,6 +234,7 @@ describe('dive/DIVE', () => {
         const dive = new DIVE();
         dive.Settings = {
             autoResize: false,
+            displayAxes: true,
             renderer: {
                 antialias: false,
                 alpha: false,

--- a/src/__test__/DIVE.test.ts
+++ b/src/__test__/DIVE.test.ts
@@ -43,6 +43,7 @@ jest.mock('../com/Communication.ts', () => {
             callback({ id: 'incorrect id' });
             callback({ id: 'test_uuid' });
         });
+        this.DestroyInstance = jest.fn();
 
         return this;
     });
@@ -71,7 +72,7 @@ jest.mock('../renderer/Renderer.ts', () => {
         this.render = jest.fn();
         this.StartRenderer = jest.fn();
         this.OnResize = jest.fn();
-
+        this.Dispose = jest.fn();
         return this;
     });
 });
@@ -187,6 +188,17 @@ describe('dive/DIVE', () => {
         expect((window as any).DIVE.PrintScene).toBeDefined();
         console.log = jest.fn();
         expect(() => (window as any).DIVE.PrintScene()).not.toThrow();
+    });
+
+    it('should dispose', () => {
+        let dive = new DIVE();
+        expect(() => dive.Dispose()).not.toThrow();
+
+        const settings = {
+            displayAxes: true,
+        }
+        dive = new DIVE(settings);
+        expect(() => dive.Dispose()).not.toThrow();
     });
 
     it('should instantiate with settings', () => {

--- a/src/__test__/DIVE.test.ts
+++ b/src/__test__/DIVE.test.ts
@@ -30,6 +30,12 @@ jest.mock('three', () => {
     }
 });
 
+jest.mock('three/src/math/MathUtils', () => {
+    return {
+        generateUUID: () => { return 'test_uuid'; },
+    }
+});
+
 jest.mock('../renderer/Renderer.ts', () => {
     return jest.fn(function () {
         this.domElement = {

--- a/src/animation/AnimationSystem.ts
+++ b/src/animation/AnimationSystem.ts
@@ -1,4 +1,5 @@
 import { update as updateTween } from "@tweenjs/tween.js";
+import DIVERenderer from "../renderer/Renderer";
 
 /**
  * Updates all animations.
@@ -8,6 +9,21 @@ import { update as updateTween } from "@tweenjs/tween.js";
  */
 
 export default class DIVEAnimationSystem {
+    private _renderer: DIVERenderer;
+    private _rendererCallbackId: string;
+
+    constructor(renderer: DIVERenderer) {
+        this._renderer = renderer;
+
+        this._rendererCallbackId = this._renderer.AddPreRenderCallback(() => {
+            this.update();
+        })
+    }
+
+    public Dispose(): void {
+        this._renderer.RemovePreRenderCallback(this._rendererCallbackId);
+    }
+
     public update(): void {
         updateTween();
     }

--- a/src/animation/AnimationSystem.ts
+++ b/src/animation/AnimationSystem.ts
@@ -1,5 +1,5 @@
 import { update as updateTween } from "@tweenjs/tween.js";
-import DIVERenderer from "../renderer/Renderer";
+import { DIVERenderer } from "../renderer/Renderer";
 
 /**
  * Updates all animations.

--- a/src/animation/__test__/AnimationSystem.test.ts
+++ b/src/animation/__test__/AnimationSystem.test.ts
@@ -1,3 +1,4 @@
+import DIVERenderer from '../../renderer/Renderer';
 import DIVEAnimationSystem from '../AnimationSystem';
 
 jest.mock('@tweenjs/tween.js', () => {
@@ -6,14 +7,34 @@ jest.mock('@tweenjs/tween.js', () => {
     }
 });
 
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+    getViewport: jest.fn(),
+    setViewport: jest.fn(),
+    AddPreRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    AddPostRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    RemovePreRenderCallback: jest.fn(),
+    RemovePostRenderCallback: jest.fn(),
+} as unknown as DIVERenderer;
+
 describe('dive/animation/DIVEAnimationSystem', () => {
     it('should instantiate', () => {
-        const anim = new DIVEAnimationSystem();
+        const anim = new DIVEAnimationSystem(mockRenderer);
         expect(anim).toBeDefined();
     });
 
     it('should update', () => {
-        const anim = new DIVEAnimationSystem();
+        const anim = new DIVEAnimationSystem(mockRenderer);
         expect(() => anim.update()).not.toThrow();
+    });
+
+    it('should dispose', () => {
+        const anim = new DIVEAnimationSystem(mockRenderer);
+        expect(() => anim.Dispose()).not.toThrow();
     });
 });

--- a/src/animation/__test__/AnimationSystem.test.ts
+++ b/src/animation/__test__/AnimationSystem.test.ts
@@ -1,4 +1,4 @@
-import DIVERenderer from '../../renderer/Renderer';
+import { DIVERenderer } from '../../renderer/Renderer';
 import DIVEAnimationSystem from '../AnimationSystem';
 
 jest.mock('@tweenjs/tween.js', () => {

--- a/src/axiscamera/AxisCamera.ts
+++ b/src/axiscamera/AxisCamera.ts
@@ -1,7 +1,10 @@
-import { AxesHelper, Color, Material, Matrix4, OrthographicCamera } from "three";
+import { AxesHelper, Color, Material, Matrix4, OrthographicCamera, Vector4 } from "three";
 import SpriteText from "three-spritetext";
 import { COORDINATE_LAYER_MASK } from "../constant/VisibilityLayerMask.ts";
 import { AxesColorRed, AxesColorGreen, AxesColorBlue, AxesColorRedLetter, AxesColorGreenLetter, AxesColorBlueLetter } from "../constant/AxisHelperColors.ts";
+import DIVERenderer from "../renderer/Renderer.ts";
+import DIVEScene from "../scene/Scene.ts";
+import DIVEOrbitControls from "../controls/OrbitControls.ts";
 
 /**
  * Shows the scene axes in the bottom left corner of the screen.
@@ -12,7 +15,12 @@ import { AxesColorRed, AxesColorGreen, AxesColorBlue, AxesColorRedLetter, AxesCo
 export default class DIVEAxisCamera extends OrthographicCamera {
     private axesHelper: AxesHelper;
 
-    constructor() {
+    private _renderer: DIVERenderer;
+    private _scene: DIVEScene;
+
+    private _renderCallbackId: string;
+
+    constructor(renderer: DIVERenderer, scene: DIVEScene, controls: DIVEOrbitControls) {
         super(-1, 1, 1, -1, 0.1, 100);
 
         this.layers.mask = COORDINATE_LAYER_MASK;
@@ -42,6 +50,36 @@ export default class DIVEAxisCamera extends OrthographicCamera {
         this.axesHelper.add(z);
 
         this.add(this.axesHelper);
+
+        // attach everything to current scene and render cycle
+        this._renderer = renderer;
+        this._scene = scene;
+        this._scene.add(this);
+
+        const restoreViewport = new Vector4();
+
+        this._renderCallbackId = renderer.AddPostRenderCallback(() => {
+            const restoreBackground = scene.background;
+            scene.background = null;
+
+            renderer.getViewport(restoreViewport);
+            renderer.setViewport(0, 0, 150, 150);
+            renderer.autoClear = false;
+
+            this.SetFromCameraMatrix(controls.object.matrix);
+
+            renderer.render(scene, this);
+
+            renderer.setViewport(restoreViewport);
+            renderer.autoClear = true;
+
+            scene.background = restoreBackground;
+        });
+    }
+
+    public Dispose(): void {
+        this._renderer.RemovePostRenderCallback(this._renderCallbackId);
+        this._scene.remove(this);
     }
 
     public SetFromCameraMatrix(matrix: Matrix4): void {

--- a/src/axiscamera/AxisCamera.ts
+++ b/src/axiscamera/AxisCamera.ts
@@ -2,7 +2,7 @@ import { AxesHelper, Color, Material, Matrix4, OrthographicCamera, Vector4 } fro
 import SpriteText from "three-spritetext";
 import { COORDINATE_LAYER_MASK } from "../constant/VisibilityLayerMask.ts";
 import { AxesColorRed, AxesColorGreen, AxesColorBlue, AxesColorRedLetter, AxesColorGreenLetter, AxesColorBlueLetter } from "../constant/AxisHelperColors.ts";
-import DIVERenderer from "../renderer/Renderer.ts";
+import { DIVERenderer } from "../renderer/Renderer.ts";
 import DIVEScene from "../scene/Scene.ts";
 import DIVEOrbitControls from "../controls/OrbitControls.ts";
 

--- a/src/axiscamera/__test__/AxisCamera.test.ts
+++ b/src/axiscamera/__test__/AxisCamera.test.ts
@@ -1,5 +1,63 @@
-import { Matrix4 } from 'three';
+import { AxesHelper, Matrix4, OrthographicCamera, Vector4 } from 'three';
 import DIVEAxisCamera from '../AxisCamera';
+import DIVERenderer from '../../renderer/Renderer';
+import DIVEScene from '../../scene/Scene';
+import DIVEOrbitControls from '../../controls/OrbitControls';
+
+jest.mock('three', () => {
+    return {
+        Vector4: jest.fn(),
+        Color: jest.fn(function () {
+            this.getHexString = jest.fn().mockReturnValue('ffffff');
+            return this;
+        }),
+        Matrix4: jest.fn(function () {
+            this.extractRotation = jest.fn(() => { return this; });
+            this.invert = jest.fn(() => { return this; });
+            this.elements = [
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1,
+            ];
+            return this;
+        }),
+        OrthographicCamera: jest.fn(function () {
+
+            this.isObject3D = true;
+            this.parent = null;
+            this.dispatchEvent = jest.fn();
+            this.layers = {
+                mask: 0,
+            };
+            this.position = {
+                set: jest.fn(),
+            };
+            this.add = jest.fn();
+            return this;
+        }),
+        AxesHelper: jest.fn(function () {
+            this.isObject3D = true;
+            this.parent = null;
+            this.dispatchEvent = jest.fn();
+            this.layers = {
+                mask: 0,
+            };
+            this.position = {
+                set: jest.fn(),
+            };
+            this.add = jest.fn();
+            this.material = {
+                depthTest: false,
+            };
+            this.setColors = jest.fn();
+            this.rotation = {
+                setFromRotationMatrix: jest.fn(),
+            }
+            return this;
+        }),
+    }
+});
 
 jest.mock('three-spritetext', () => {
     return jest.fn(() => {
@@ -19,10 +77,122 @@ jest.mock('three-spritetext', () => {
     )
 });
 
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+    getViewport: jest.fn(),
+    setViewport: jest.fn(),
+    AddPostRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    RemovePostRenderCallback: jest.fn(),
+} as unknown as DIVERenderer;
+
+const mockScene = {
+    add: jest.fn(),
+    remove: jest.fn(),
+    SetBackground: jest.fn(),
+    AddSceneObject: jest.fn(),
+    UpdateSceneObject: jest.fn(),
+    DeleteSceneObject: jest.fn(),
+    PlaceOnFloor: jest.fn(),
+    GetSceneObject: jest.fn(),
+    background: {
+        getHexString: jest.fn().mockReturnValue('ffffff'),
+    },
+    Root: {
+        Floor: {
+            isFloor: true,
+            visible: true,
+            material: {
+                color: {
+                    getHexString: jest.fn().mockReturnValue('ffffff'),
+                },
+            },
+            SetVisibility: jest.fn(),
+            SetColor: jest.fn(),
+        },
+        Grid: {
+            SetVisibility: jest.fn(),
+        },
+    },
+} as unknown as DIVEScene;
+
+const mockController = {
+    enableDamping: true,
+    dampingFactor: 0.25,
+    enableZoom: true,
+    enablePan: true,
+    minPolarAngle: 0,
+    maxPolarAngle: Math.PI,
+    minDistance: 0,
+    maxDistance: Infinity,
+    rotateSpeed: 0.5,
+    panSpeed: 0.5,
+    zoomSpeed: 0.5,
+    keyPanSpeed: 0.5,
+    screenSpacePanning: true,
+    autoRotate: false,
+    autoRotateSpeed: 2.0,
+    enableKeys: true,
+    keys: {
+        LEFT: 37,
+        UP: 38,
+        RIGHT: 39,
+        BOTTOM: 40,
+    },
+    mouseButtons: {
+        LEFT: 0,
+        MIDDLE: 1,
+        RIGHT: 2,
+    },
+    target: {
+        x: 4,
+        y: 5,
+        z: 6,
+        set: jest.fn(),
+        clone: jest.fn().mockReturnValue({ x: 4, y: 5, z: 6 }),
+        copy: jest.fn(),
+    },
+    update: jest.fn(),
+    dispose: jest.fn(),
+    ZoomIn: jest.fn(),
+    ZoomOut: jest.fn(),
+    object: {
+        position: {
+            x: 1,
+            y: 2,
+            z: 3,
+            clone: jest.fn().mockReturnValue({ x: 1, y: 2, z: 3 }),
+            copy: jest.fn(),
+        },
+        quaternion: {
+            x: 1,
+            y: 2,
+            z: 3,
+            w: 4,
+            clone: jest.fn().mockReturnValue({ x: 1, y: 2, z: 3, w: 4 }),
+            copy: jest.fn(),
+        },
+        SetCameraLayer: jest.fn(),
+        OnResize: jest.fn(),
+        layers: {
+            mask: 1,
+        },
+    },
+    MoveTo: jest.fn(),
+    RevertLast: jest.fn(),
+} as unknown as DIVEOrbitControls;
+
+let textAxisCamera: DIVEAxisCamera;
+
 describe('dive/axiscamera/DIVEAxisCamera', () => {
+    beforeEach(() => {
+        textAxisCamera = new DIVEAxisCamera(mockRenderer, mockScene, mockController);
+    });
+
     it('should instantiate', () => {
-        const cam = new DIVEAxisCamera();
-        expect(cam).toBeDefined();
+        expect(textAxisCamera).toBeDefined();
     });
 
     it('should set rotation from Matrix4', () => {
@@ -35,7 +205,10 @@ describe('dive/axiscamera/DIVEAxisCamera', () => {
                 0, 0, 0, 1,
             ],
         } as Matrix4;
-        const cam = new DIVEAxisCamera();
-        cam.SetFromCameraMatrix(matrix);
+        textAxisCamera.SetFromCameraMatrix(matrix);
+    });
+
+    it('should dispose', () => {
+        textAxisCamera.Dispose();
     });
 });

--- a/src/axiscamera/__test__/AxisCamera.test.ts
+++ b/src/axiscamera/__test__/AxisCamera.test.ts
@@ -1,6 +1,6 @@
 import { AxesHelper, Matrix4, OrthographicCamera, Vector4 } from 'three';
 import DIVEAxisCamera from '../AxisCamera';
-import DIVERenderer from '../../renderer/Renderer';
+import { DIVERenderer } from '../../renderer/Renderer';
 import DIVEScene from '../../scene/Scene';
 import DIVEOrbitControls from '../../controls/OrbitControls';
 

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -9,7 +9,7 @@ import type DIVEToolbox from "../toolbox/Toolbox.ts";
 import type DIVEMediaCreator from "../mediacreator/MediaCreator.ts";
 import type DIVEOrbitControls from "../controls/OrbitControls.ts";
 import type DIVEModel from "../model/Model.ts";
-import type DIVERenderer from "../renderer/Renderer.ts";
+import { type DIVERenderer } from "../renderer/Renderer.ts";
 import { type DIVESelectable } from "../interface/Selectable.ts";
 import { isSelectTool } from "../toolbox/select/SelectTool.ts";
 
@@ -144,6 +144,10 @@ export default class DIVECommunication {
             }
             case 'RESET_CAMERA': {
                 returnValue = this.resetCamera(payload as Actions['RESET_CAMERA']['PAYLOAD']);
+                break;
+            }
+            case 'COMPUTE_ENCOMPASSING_VIEW': {
+                returnValue = this.computeEncompassingView(payload as Actions['COMPUTE_ENCOMPASSING_VIEW']['PAYLOAD']);
                 break;
             }
             case 'SET_CAMERA_LAYER': {
@@ -388,6 +392,15 @@ export default class DIVECommunication {
         this.controller.RevertLast(payload.duration);
 
         return true;
+    }
+
+    private computeEncompassingView(payload: Actions['COMPUTE_ENCOMPASSING_VIEW']['PAYLOAD']): Actions['COMPUTE_ENCOMPASSING_VIEW']['RETURN'] {
+        const sceneBB = this.scene.ComputeSceneBB();
+
+        const transform = this.controller.ComputeEncompassingView(sceneBB);
+        Object.assign(payload, transform);
+
+        return transform;
     }
 
     private zoomCamera(payload: Actions['ZOOM_CAMERA']['PAYLOAD']): Actions['ZOOM_CAMERA']['RETURN'] {

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -6,9 +6,9 @@ import { type Color, type MeshStandardMaterial } from "three";
 import { type COMLight, type COMModel, type COMEntity, type COMPov } from "./types.ts";
 import type DIVEScene from "../scene/Scene.ts";
 import type DIVEToolbox from "../toolbox/Toolbox.ts";
-import type DIVEMediaCreator from "../mediacreator/MediaCreator.ts";
 import type DIVEOrbitControls from "../controls/OrbitControls.ts";
 import type DIVEModel from "../model/Model.ts";
+import { type DIVEMediaCreator } from "../mediacreator/MediaCreator.ts";
 import { type DIVERenderer } from "../renderer/Renderer.ts";
 import { type DIVESelectable } from "../interface/Selectable.ts";
 import { isSelectTool } from "../toolbox/select/SelectTool.ts";
@@ -53,7 +53,7 @@ export default class DIVECommunication {
     private _mediaGenerator: DIVEMediaCreator | null;
     private get mediaGenerator(): DIVEMediaCreator {
         if (!this._mediaGenerator) {
-            const DIVEMediaCreator = require('../mediacreator/MediaCreator.ts').default as typeof import('../mediacreator/MediaCreator.ts').default;
+            const DIVEMediaCreator = require('../mediacreator/MediaCreator.ts').default as typeof import('../mediacreator/MediaCreator.ts').DIVEMediaCreator;
             this._mediaGenerator = new DIVEMediaCreator(this.renderer, this.scene, this.controller);
         }
         return this._mediaGenerator;

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -398,6 +398,8 @@ export default class DIVECommunication {
         if (payload.name !== undefined) this.scene.name = payload.name;
         if (payload.backgroundColor !== undefined) this.scene.SetBackground(payload.backgroundColor);
 
+        if (payload.gridEnabled !== undefined) this.scene.Root.Grid.SetVisibility(payload.gridEnabled);
+
         if (payload.floorEnabled !== undefined) this.scene.Root.Floor.SetVisibility(payload.floorEnabled);
         if (payload.floorColor !== undefined) this.scene.Root.Floor.SetColor(payload.floorColor);
 
@@ -406,6 +408,7 @@ export default class DIVECommunication {
         // TODO optmize this
         payload.name = this.scene.name;
         payload.backgroundColor = '#' + (this.scene.background as Color).getHexString();
+        payload.gridEnabled = this.scene.Root.Grid.visible;
         payload.floorEnabled = this.scene.Root.Floor.visible;
         payload.floorColor = '#' + (this.scene.Root.Floor.material as MeshStandardMaterial).color.getHexString();
 

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -8,10 +8,10 @@ import type DIVEScene from "../scene/Scene.ts";
 import type DIVEToolbox from "../toolbox/Toolbox.ts";
 import type DIVEMediaCreator from "../mediacreator/MediaCreator.ts";
 import type DIVEOrbitControls from "../controls/OrbitControls.ts";
-import type DIVESelectTool from "../toolbox/select/SelectTool.ts";
 import type DIVEModel from "../model/Model.ts";
 import type DIVERenderer from "../renderer/Renderer.ts";
 import { type DIVESelectable } from "../interface/Selectable.ts";
+import { isSelectTool } from "../toolbox/select/SelectTool.ts";
 
 type EventListener<Action extends keyof Actions> = (payload: Actions[Action]['PAYLOAD']) => void;
 
@@ -290,8 +290,10 @@ export default class DIVECommunication {
 
         if (!('isSelectable' in sceneObject)) return false;
 
-        this.toolbox.UseTool('select');
-        (this.toolbox.GetActiveTool() as DIVESelectTool).AttachGizmo(sceneObject as DIVESelectable);
+        const activeTool = this.toolbox.GetActiveTool();
+        if (activeTool && isSelectTool(activeTool)) {
+            activeTool.AttachGizmo(sceneObject as DIVESelectable);
+        }
 
         // copy object to payload to use later
         Object.assign(payload, object);
@@ -308,8 +310,10 @@ export default class DIVECommunication {
 
         if (!('isSelectable' in sceneObject)) return false;
 
-        this.toolbox.UseTool('select');
-        (this.toolbox.GetActiveTool() as DIVESelectTool).DetachGizmo();
+        const activeTool = this.toolbox.GetActiveTool();
+        if (activeTool && isSelectTool(activeTool)) {
+            activeTool.DetachGizmo();
+        }
 
         // copy object to payload to use later
         Object.assign(payload, object);

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -1,13 +1,17 @@
-import { Color, MeshStandardMaterial, MathUtils } from "three";
-import DIVEScene from "../scene/Scene.ts";
 import { Actions } from "./actions/index.ts";
-import { COMLight, COMModel, COMEntity, COMPov } from "./types.ts";
-import DIVEToolbox from "../toolbox/Toolbox.ts";
-import DIVEMediaCreator from "../mediacreator/MediaCreator.ts";
-import DIVEOrbitControls from "../controls/OrbitControls.ts";
-import { DIVESelectable } from "../interface/Selectable.ts";
-import DIVESelectTool from "../toolbox/select/SelectTool.ts";
+import { generateUUID } from 'three/src/math/MathUtils';
+
+// type imports
+import { type Color, type MeshStandardMaterial } from "three";
+import { type COMLight, type COMModel, type COMEntity, type COMPov } from "./types.ts";
+import type DIVEScene from "../scene/Scene.ts";
+import type DIVEToolbox from "../toolbox/Toolbox.ts";
+import type DIVEMediaCreator from "../mediacreator/MediaCreator.ts";
+import type DIVEOrbitControls from "../controls/OrbitControls.ts";
+import type DIVESelectTool from "../toolbox/select/SelectTool.ts";
 import type DIVEModel from "../model/Model.ts";
+import type DIVERenderer from "../renderer/Renderer.ts";
+import { type DIVESelectable } from "../interface/Selectable.ts";
 
 type EventListener<Action extends keyof Actions> = (payload: Actions[Action]['PAYLOAD']) => void;
 
@@ -41,22 +45,32 @@ export default class DIVECommunication {
     }
 
     private id: string;
+    private renderer: DIVERenderer;
     private scene: DIVEScene;
     private controller: DIVEOrbitControls;
     private toolbox: DIVEToolbox;
-    private mediaGenerator: DIVEMediaCreator;
+
+    private _mediaGenerator: DIVEMediaCreator | null;
+    private get mediaGenerator(): DIVEMediaCreator {
+        if (!this._mediaGenerator) {
+            const DIVEMediaCreator = require('../mediacreator/MediaCreator.ts').default as typeof import('../mediacreator/MediaCreator.ts').default;
+            this._mediaGenerator = new DIVEMediaCreator(this.renderer, this.scene, this.controller);
+        }
+        return this._mediaGenerator;
+    }
 
     private registered: Map<string, COMEntity> = new Map();
 
     // private listeners: { [key: string]: EventListener[] } = {};
     private listeners: Map<keyof Actions, EventListener<keyof Actions>[]> = new Map();
 
-    constructor(scene: DIVEScene, controls: DIVEOrbitControls, toolbox: DIVEToolbox, mediaGenerator: DIVEMediaCreator) {
-        this.id = MathUtils.generateUUID();
+    constructor(renderer: DIVERenderer, scene: DIVEScene, controls: DIVEOrbitControls, toolbox: DIVEToolbox) {
+        this.id = generateUUID();
+        this.renderer = renderer;
         this.scene = scene;
         this.controller = controls;
         this.toolbox = toolbox;
-        this.mediaGenerator = mediaGenerator;
+        this._mediaGenerator = null;
 
         DIVECommunication.__instances.push(this);
     }

--- a/src/com/__test__/Communication.test.ts
+++ b/src/com/__test__/Communication.test.ts
@@ -26,14 +26,30 @@ import '../actions/toolbox/select/setgizmomode';
 import '../actions/toolbox/transform/setgizmovisible';
 import '../actions/camera/getcameratransform';
 import DIVEOrbitControls from '../../controls/OrbitControls';
+import DIVERenderer from '../../renderer/Renderer';
 import { COMLight, COMModel, COMPov } from '../types';
-import { Object3D } from 'three';
+import { Object3D, Quaternion } from 'three';
 
 jest.mock('three/src/math/MathUtils', () => {
     return {
         generateUUID: jest.fn().mockReturnValue('uuid'),
     }
 });
+
+jest.mock('../../mediacreator/MediaCreator', () => {
+    return {
+        default: jest.fn(function () {
+            this.GenerateMedia = jest.fn();
+
+            return this;
+        }),
+    }
+});
+
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+} as unknown as DIVERenderer;
 
 const mockScene = {
     SetBackground: jest.fn(),
@@ -56,7 +72,10 @@ const mockScene = {
             },
             SetVisibility: jest.fn(),
             SetColor: jest.fn(),
-        }
+        },
+        Grid: {
+            SetVisibility: jest.fn(),
+        },
     },
 } as unknown as DIVEScene;
 
@@ -108,7 +127,19 @@ const mockController = {
             clone: jest.fn().mockReturnValue({ x: 1, y: 2, z: 3 }),
             copy: jest.fn(),
         },
+        quaternion: {
+            x: 1,
+            y: 2,
+            z: 3,
+            w: 4,
+            clone: jest.fn().mockReturnValue({ x: 1, y: 2, z: 3, w: 4 }),
+            copy: jest.fn(),
+        },
         SetCameraLayer: jest.fn(),
+        OnResize: jest.fn(),
+        layers: {
+            mask: 1,
+        },
     },
     MoveTo: jest.fn(),
     RevertLast: jest.fn(),
@@ -126,15 +157,12 @@ const mockToolBox = {
     SetGizmoVisibility: jest.fn(),
 } as unknown as DIVEToolbox;
 
-const mockMediaCreator = {
-    GenerateMedia: jest.fn(),
-} as unknown as DIVEMediaCreator;
 let testCom: DIVECommunication;
 
 
 describe('dive/communication/DIVECommunication', () => {
     beforeEach(() => {
-        testCom = new DIVECommunication(mockScene, mockController, mockToolBox, mockMediaCreator);
+        testCom = new DIVECommunication(mockRenderer, mockScene, mockController, mockToolBox);
     });
 
     afterEach(() => {
@@ -647,6 +675,7 @@ describe('dive/communication/DIVECommunication', () => {
             backgroundColor: 'ffffff',
             floorEnabled: true,
             floorColor: 'ffffff',
+            gridEnabled: true,
         });
         expect(success0).toBe(true);
 
@@ -655,6 +684,7 @@ describe('dive/communication/DIVECommunication', () => {
             backgroundColor: undefined,
             floorEnabled: undefined,
             floorColor: undefined,
+            gridEnabled: undefined,
         });
         expect(success1).toBe(true);
     });

--- a/src/com/__test__/Communication.test.ts
+++ b/src/com/__test__/Communication.test.ts
@@ -1,7 +1,4 @@
 import DIVECommunication from '../Communication';
-import DIVEScene from '../../scene/Scene';
-import DIVEToolbox from '../../toolbox/Toolbox';
-import DIVEMediaCreator from '../../mediacreator/MediaCreator';
 import '..';
 import '../types';
 import '../actions';
@@ -25,10 +22,13 @@ import '../actions/scene/updatescene';
 import '../actions/toolbox/select/setgizmomode';
 import '../actions/toolbox/transform/setgizmovisible';
 import '../actions/camera/getcameratransform';
-import DIVEOrbitControls from '../../controls/OrbitControls';
-import DIVERenderer from '../../renderer/Renderer';
-import { COMLight, COMModel, COMPov } from '../types';
-import { Object3D, Quaternion } from 'three';
+import type DIVEScene from '../../scene/Scene';
+import type DIVEToolbox from '../../toolbox/Toolbox';
+import type DIVEOrbitControls from '../../controls/OrbitControls';
+import { type DIVERenderer } from '../../renderer/Renderer';
+import { type COMLight, type COMModel, type COMPov } from '../types';
+import { type Object3D } from 'three';
+import { DIVESelectTool, isSelectTool } from '../../toolbox/select/SelectTool';
 
 jest.mock('three/src/math/MathUtils', () => {
     return {
@@ -42,6 +42,18 @@ jest.mock('../../mediacreator/MediaCreator', () => {
             this.GenerateMedia = jest.fn();
 
             return this;
+        }),
+    }
+});
+
+jest.mock('../../toolbox/select/SelectTool', () => {
+    return {
+        isSelectTool: jest.fn().mockReturnValue(true),
+        DIVESelectTool: jest.fn().mockImplementation(() => {
+            return {
+                AttachGizmo: jest.fn(),
+                DetachGizmo: jest.fn(),
+            };
         }),
     }
 });
@@ -77,6 +89,7 @@ const mockScene = {
             SetVisibility: jest.fn(),
         },
     },
+    ComputeSceneBB: jest.fn(),
 } as unknown as DIVEScene;
 
 const mockController = {
@@ -143,15 +156,17 @@ const mockController = {
     },
     MoveTo: jest.fn(),
     RevertLast: jest.fn(),
+    ComputeEncompassingView: jest.fn().mockReturnValue({
+        position: { x: 1, y: 2, z: 3 },
+        target: { x: 4, y: 5, z: 6 }
+    }),
 } as unknown as DIVEOrbitControls;
 
-const mockAttach = jest.fn();
-const mockDetach = jest.fn();
 const mockToolBox = {
     UseTool: jest.fn(),
     GetActiveTool: jest.fn().mockReturnValue({
-        AttachGizmo: mockAttach,
-        DetachGizmo: mockDetach,
+        AttachGizmo: jest.fn(),
+        DetachGizmo: jest.fn(),
     }),
     SetGizmoMode: jest.fn(),
     SetGizmoVisibility: jest.fn(),
@@ -220,13 +235,6 @@ describe('dive/communication/DIVECommunication', () => {
         } as COMLight;
         expect(() => testCom.PerformAction('ADD_OBJECT', payload)).not.toThrow();
     });
-
-    // it('should not dispatch with invalid action type', () => {
-    //     const listener = jest.fn();
-    //     testCom.Subscribe('GET_ALL_OBJECTS', listener);
-    //     testCom.dispatch('INVALID_ACTION_TYPE', {});
-    //     expect(listener).toHaveBeenCalledTimes(0);
-    // });
 
     it('should perform action ADD_OBJECT', () => {
         const payload = {
@@ -462,6 +470,19 @@ describe('dive/communication/DIVECommunication', () => {
         expect(successSet).toBe(true);
     });
 
+    it('should perform action COMPUTE_ENCOMPASSING_VIEW', () => {
+        const payload = {};
+        const transform = testCom.PerformAction('COMPUTE_ENCOMPASSING_VIEW', payload);
+        expect(transform).toStrictEqual({
+            position: { x: 1, y: 2, z: 3 },
+            target: { x: 4, y: 5, z: 6 }
+        });
+        expect(payload).toStrictEqual({
+            position: { x: 1, y: 2, z: 3 },
+            target: { x: 4, y: 5, z: 6 }
+        });
+    });
+
     it('should perform action GET_ALL_SCENE_DATA', () => {
         testCom.PerformAction('ADD_OBJECT', {
             entityType: "pov",
@@ -572,7 +593,6 @@ describe('dive/communication/DIVECommunication', () => {
         jest.spyOn(mockScene, 'GetSceneObject').mockReturnValueOnce({ isSelectable: true } as unknown as Object3D);
         const success3 = testCom.PerformAction('SELECT_OBJECT', { id: 'test0' });
         expect(success3).toBe(true);
-        expect(mockAttach).toHaveBeenCalledTimes(1);
     });
 
     it('should perform action DESELECT_OBJECT', () => {
@@ -598,7 +618,6 @@ describe('dive/communication/DIVECommunication', () => {
         jest.spyOn(mockScene, 'GetSceneObject').mockReturnValueOnce({ isSelectable: true } as unknown as Object3D);
         const success3 = testCom.PerformAction('DESELECT_OBJECT', { id: 'test0' });
         expect(success3).toBe(true);
-        expect(mockDetach).toHaveBeenCalledTimes(1);
     });
 
     it('should perform action SET_CAMERA_TRANSFORM', () => {

--- a/src/com/actions/camera/computeencompassingview.ts
+++ b/src/com/actions/camera/computeencompassingview.ts
@@ -1,0 +1,9 @@
+import { Vector3Like } from "three";
+
+export default interface COMPUTE_ENCOMPASSING_VIEW {
+    'PAYLOAD': object,
+    'RETURN': {
+        position: Vector3Like,
+        target: Vector3Like
+    },
+};

--- a/src/com/actions/index.ts
+++ b/src/com/actions/index.ts
@@ -20,6 +20,7 @@ import DESELECT_OBJECT from "./object/deselectobject.ts";
 import GET_CAMERA_TRANSFORM from "./camera/getcameratransform.ts";
 import DROP_IT from "./object/model/dropit.ts";
 import SET_GIZMO_VISIBILITY from "./toolbox/transform/setgizmovisible.js";
+import COMPUTE_ENCOMPASSING_VIEW from "./camera/computeencompassingview.ts";
 
 export type Actions = {
     GET_ALL_SCENE_DATA: GET_ALL_SCENE_DATA,
@@ -37,6 +38,7 @@ export type Actions = {
     GET_CAMERA_TRANSFORM: GET_CAMERA_TRANSFORM,
     MOVE_CAMERA: MOVE_CAMERA,
     RESET_CAMERA: RESET_CAMERA,
+    COMPUTE_ENCOMPASSING_VIEW: COMPUTE_ENCOMPASSING_VIEW,
     SET_CAMERA_LAYER: SET_CAMERA_LAYER,
     ZOOM_CAMERA: ZOOM_CAMERA,
     SET_GIZMO_MODE: SET_GIZMO_MODE,

--- a/src/com/actions/scene/updatescene.ts
+++ b/src/com/actions/scene/updatescene.ts
@@ -2,6 +2,7 @@ export default interface UPDATE_SCENE {
     'PAYLOAD': {
         name?: string,
         backgroundColor?: string | number,
+        gridEnabled?: boolean,
         floorEnabled?: boolean,
         floorColor?: string | number
     },

--- a/src/controls/OrbitControls.ts
+++ b/src/controls/OrbitControls.ts
@@ -1,7 +1,7 @@
 import { OrbitControls } from "three/examples/jsm/Addons.js";
 import DIVEPerspectiveCamera from "../camera/PerspectiveCamera.ts";
-import DIVERenderer from "../renderer/Renderer.ts";
-import { MathUtils, Vector3Like } from "three";
+import { DIVERenderer } from "../renderer/Renderer.ts";
+import { type Box3, MathUtils, Vector3, Vector3Like } from "three";
 import { Easing, Tween } from "@tweenjs/tween.js";
 
 export type DIVEOrbitControlsSettings = {
@@ -47,6 +47,18 @@ export default class DIVEOrbitControls extends OrbitControls {
 
         this.enableDamping = settings.enableDamping;
         this.dampingFactor = settings.dampingFactor;
+    }
+
+    public ComputeEncompassingView(bb: Box3): { position: Vector3Like, target: Vector3Like } {
+        const center = bb.getCenter(new Vector3());
+        const size = bb.getSize(new Vector3());
+        const distance = Math.max(size.x, size.y, size.z) * 1.25;
+        const direction = this.object.position.clone().normalize();
+
+        return {
+            position: direction.multiplyScalar(distance),
+            target: center,
+        };
     }
 
     public ZoomIn(by?: number): void {

--- a/src/controls/__test__/OrbitControls.test.ts
+++ b/src/controls/__test__/OrbitControls.test.ts
@@ -1,6 +1,7 @@
 import DIVEOrbitControls from '../OrbitControls';
-import DIVEPerspectiveCamera from '../../camera/PerspectiveCamera';
-import DIVERenderer, { DIVERendererDefaultSettings } from '../../renderer/Renderer';
+import type DIVEPerspectiveCamera from '../../camera/PerspectiveCamera';
+import { DIVERenderer } from '../../renderer/Renderer';
+import { Box3 } from 'three';
 
 jest.mock('three/examples/jsm/Addons.js', () => {
     return {
@@ -88,11 +89,32 @@ const moveToDuration = 1000;
 
 const mockCamera = {
     position: {
-        clone: jest.fn(),
+        clone: jest.fn(() => {
+            return mockCamera.position;
+        }),
+        normalize: jest.fn(() => {
+            return mockCamera.position;
+        }),
+        multiplyScalar: jest.fn(() => {
+            return mockCamera.position;
+        }),
     },
     lookAt: jest.fn(),
 } as unknown as DIVEPerspectiveCamera;
-const mockRenderer: DIVERenderer = new DIVERenderer(DIVERendererDefaultSettings);
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+    getViewport: jest.fn(),
+    setViewport: jest.fn(),
+    AddPreRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    AddPostRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    RemovePreRenderCallback: jest.fn(),
+    RemovePostRenderCallback: jest.fn(),
+} as unknown as DIVERenderer;
 
 describe('dive/controls/DIVEOrbitControls', () => {
     afterEach(() => {
@@ -102,6 +124,11 @@ describe('dive/controls/DIVEOrbitControls', () => {
     it('should instantiate', () => {
         const controller = new DIVEOrbitControls(mockCamera, mockRenderer);
         expect(controller).toBeDefined();
+    });
+
+    it('should compute encompassing view', () => {
+        const controller = new DIVEOrbitControls(mockCamera, mockRenderer);
+        expect(() => controller.ComputeEncompassingView(new Box3())).not.toThrow();
     });
 
     it('should zoom in with default value', () => {

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -217,6 +217,13 @@ export default class DIVE {
         }
     }
 
+    public Dispose(): void {
+        this.removeResizeObserver();
+        this.renderer.Dispose();
+        this.axisCamera?.Dispose();
+        this.communication.DestroyInstance();
+    }
+
     // methods
     public OnResize(width: number, height: number): void {
         // resize renderer

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -3,7 +3,6 @@ import DIVERenderer, { DIVERendererDefaultSettings, DIVERendererSettings } from 
 import DIVEScene from "./scene/Scene.ts";
 import DIVEPerspectiveCamera, { DIVEPerspectiveCameraDefaultSettings, DIVEPerspectiveCameraSettings } from "./camera/PerspectiveCamera.ts";
 import DIVEOrbitControls, { DIVEOrbitControlsDefaultSettings, DIVEOrbitControlsSettings } from "./controls/OrbitControls.ts";
-import DIVEMediaCreator from "./mediacreator/MediaCreator.ts";
 import DIVEToolbox from "./toolbox/Toolbox.ts";
 import DIVECommunication from "./com/Communication.ts";
 import DIVEAnimationSystem from "./animation/AnimationSystem.ts";
@@ -124,7 +123,6 @@ export default class DIVE {
     private scene: DIVEScene;
     private perspectiveCamera: DIVEPerspectiveCamera;
     private orbitControls: DIVEOrbitControls;
-    private mediaCreator: DIVEMediaCreator;
     private toolbox: DIVEToolbox;
     private communication: DIVECommunication;
 
@@ -184,9 +182,8 @@ export default class DIVE {
         this.scene = new DIVEScene();
         this.perspectiveCamera = new DIVEPerspectiveCamera(this._settings.perspectiveCamera);
         this.orbitControls = new DIVEOrbitControls(this.perspectiveCamera, this.renderer, this._settings.orbitControls);
-        this.mediaCreator = new DIVEMediaCreator(this.renderer, this.scene, this.orbitControls);
         this.toolbox = new DIVEToolbox(this.scene, this.orbitControls);
-        this.communication = new DIVECommunication(this.scene, this.orbitControls, this.toolbox, this.mediaCreator);
+        this.communication = new DIVECommunication(this.renderer, this.scene, this.orbitControls, this.toolbox);
 
         // initialize animation system
         this.animationSystem = new DIVEAnimationSystem();

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -1,4 +1,4 @@
-import DIVERenderer, { DIVERendererDefaultSettings, DIVERendererSettings } from "./renderer/Renderer.ts";
+import { DIVERenderer, DIVERendererDefaultSettings, DIVERendererSettings } from "./renderer/Renderer.ts";
 import DIVEScene from "./scene/Scene.ts";
 import DIVEPerspectiveCamera, { DIVEPerspectiveCameraDefaultSettings, DIVEPerspectiveCameraSettings } from "./camera/PerspectiveCamera.ts";
 import DIVEOrbitControls, { DIVEOrbitControlsDefaultSettings, DIVEOrbitControlsSettings } from "./controls/OrbitControls.ts";
@@ -86,6 +86,13 @@ export default class DIVE {
             dive.Communication.PerformAction('PLACE_ON_FLOOR', {
                 id: modelid,
             });
+
+            const transform = dive.Communication.PerformAction('COMPUTE_ENCOMPASSING_VIEW', {});
+
+            dive.Communication.PerformAction('SET_CAMERA_TRANSFORM', {
+                position: transform.position,
+                target: transform.target,
+            });
         });
 
         // instantiate model
@@ -106,7 +113,7 @@ export default class DIVE {
             backgroundColor: 0xffffff,
             gridEnabled: false,
             floorColor: 0xffffff,
-        })
+        });
 
         return dive;
     }

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -126,7 +126,7 @@ export default class DIVE {
     private communication: DIVECommunication;
 
     // additional components
-    private animationSystem: DIVEAnimationSystem;
+    private animationSystem: DIVEAnimationSystem | null;
     private axisCamera: DIVEAxisCamera | null;
 
     // getters
@@ -192,10 +192,7 @@ export default class DIVE {
         this.communication = new DIVECommunication(this.renderer, this.scene, this.orbitControls, this.toolbox);
 
         // initialize animation system
-        this.animationSystem = new DIVEAnimationSystem();
-        this.renderer.AddPreRenderCallback(() => {
-            this.animationSystem.update();
-        })
+        this.animationSystem = null;
 
         // initialize axis camera
         if (this._settings.displayAxes) {

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -1,4 +1,3 @@
-import { Vector4 } from "three";
 import DIVERenderer, { DIVERendererDefaultSettings, DIVERendererSettings } from "./renderer/Renderer.ts";
 import DIVEScene from "./scene/Scene.ts";
 import DIVEPerspectiveCamera, { DIVEPerspectiveCameraDefaultSettings, DIVEPerspectiveCameraSettings } from "./camera/PerspectiveCamera.ts";
@@ -87,7 +86,7 @@ export default class DIVE {
             dive.Communication.PerformAction('PLACE_ON_FLOOR', {
                 id: modelid,
             });
-        })
+        });
 
         // instantiate model
         dive.Communication.PerformAction('ADD_OBJECT', {
@@ -128,7 +127,7 @@ export default class DIVE {
 
     // additional components
     private animationSystem: DIVEAnimationSystem;
-    private axisCamera: DIVEAxisCamera;
+    private axisCamera: DIVEAxisCamera | null;
 
     // getters
     public get Communication(): DIVECommunication {
@@ -167,6 +166,13 @@ export default class DIVE {
             }
         }
 
+        if (settingsDelta.displayAxes) {
+            this.axisCamera = new DIVEAxisCamera(this.renderer, this.scene, this.orbitControls);
+        } else {
+            this.axisCamera?.Dispose();
+            this.axisCamera = null;
+        }
+
         Object.assign(this._settings, settings);
     }
 
@@ -192,28 +198,10 @@ export default class DIVE {
         })
 
         // initialize axis camera
-        this.axisCamera = new DIVEAxisCamera();
         if (this._settings.displayAxes) {
-            this.scene.add(this.axisCamera);
-            const restoreViewport = new Vector4();
-
-            this.renderer.AddPostRenderCallback(() => {
-                const restoreBackground = this.scene.background;
-                this.scene.background = null;
-
-                this.renderer.getViewport(restoreViewport);
-                this.renderer.setViewport(0, 0, 150, 150);
-                this.renderer.autoClear = false;
-
-                this.axisCamera.SetFromCameraMatrix(this.perspectiveCamera.matrix);
-
-                this.renderer.render(this.scene, this.axisCamera);
-
-                this.renderer.setViewport(restoreViewport);
-                this.renderer.autoClear = true;
-
-                this.scene.background = restoreBackground;
-            });
+            this.axisCamera = new DIVEAxisCamera(this.renderer, this.scene, this.orbitControls);
+        } else {
+            this.axisCamera = null;
         }
 
         // add resize observer if autoResize is enabled

--- a/src/dive.ts
+++ b/src/dive.ts
@@ -228,6 +228,7 @@ export default class DIVE {
         this.removeResizeObserver();
         this.renderer.Dispose();
         this.axisCamera?.Dispose();
+        this.toolbox.Dispose();
         this.communication.DestroyInstance();
     }
 

--- a/src/grid/Grid.ts
+++ b/src/grid/Grid.ts
@@ -19,4 +19,8 @@ export default class DIVEGrid extends Object3D {
 
         this.add(grid);
     }
+
+    public SetVisibility(visible: boolean): void {
+        this.visible = visible;
+    }
 }

--- a/src/grid/__test__/Grid.test.ts
+++ b/src/grid/__test__/Grid.test.ts
@@ -16,4 +16,11 @@ describe('dive/grid/DIVEGrid', () => {
         expect((grid.children[0] as GridHelper).material.depthTest).toBe(false);
         expect((grid.children[0] as GridHelper).layers.mask).toBe(HELPER_LAYER_MASK);
     });
+
+    it('should set visibility', () => {
+        grid.SetVisibility(false);
+        expect(grid.visible).toBe(false);
+        grid.SetVisibility(true);
+        expect(grid.visible).toBe(true);
+    });
 });

--- a/src/interface/Selectable.ts
+++ b/src/interface/Selectable.ts
@@ -15,3 +15,20 @@ export interface DIVESelectable {
 export function isSelectable(object: Object3D): object is Object3D & DIVESelectable {
     return 'isSelectable' in object;
 }
+
+export function findSelectableInterface(child: Object3D): (Object3D & DIVESelectable) | undefined {
+    if (child === undefined) return undefined;
+
+    if (child.parent === null) {
+        // in this case it is the scene itself
+        return undefined;
+    }
+
+    if (isSelectable(child)) {
+        // in this case it is the Selectable
+        return child;
+    }
+
+    // search recursively in parent
+    return findSelectableInterface(child.parent);
+}

--- a/src/interface/__test__/Interfaces.test.ts
+++ b/src/interface/__test__/Interfaces.test.ts
@@ -21,6 +21,24 @@ describe('interfaces', () => {
         expect(Selectable_DEF.isSelectable(Selectable as unknown as Object3D)).toBe(true);
     });
 
+    it('should find Selectable', () => {
+        let Selectable = {
+            isSelectable: true,
+        } as unknown as Object3D & Selectable_DEF.DIVESelectable;
+        expect(Selectable_DEF.findSelectableInterface(Selectable as unknown as Object3D)).toBe(Selectable);
+
+        let parent = {
+            isSelectable: true,
+        }
+        Selectable = {
+            parent: parent,
+        } as unknown as Object3D & Selectable_DEF.DIVESelectable;
+        expect(Selectable_DEF.findSelectableInterface(Selectable as unknown as Object3D)).toBe(parent);
+
+        Selectable = { isSelectable: true, parent: null } as unknown as Object3D & Selectable_DEF.DIVESelectable;
+        expect(Selectable_DEF.findSelectableInterface(Selectable as unknown as Object3D)).toBe(undefined);
+    });
+
     it('should identify Draggable', () => {
         const Draggable = { isDraggable: true };
         expect(Draggable_DEF.isDraggable(Draggable as unknown as Object3D)).toBe(true);

--- a/src/mediacreator/MediaCreator.ts
+++ b/src/mediacreator/MediaCreator.ts
@@ -10,7 +10,7 @@ import { Vector3Like } from "three";
  * @module
  */
 
-export default class DIVEMediaCreator {
+export class DIVEMediaCreator {
     private renderer: DIVERenderer;
     private scene: DIVEScene;
     private controller: DIVEOrbitControls;

--- a/src/mediacreator/MediaCreator.ts
+++ b/src/mediacreator/MediaCreator.ts
@@ -1,6 +1,6 @@
 import DIVEPerspectiveCamera from "../camera/PerspectiveCamera.ts";
 import DIVEScene from "../scene/Scene.ts";
-import DIVERenderer from "../renderer/Renderer.ts";
+import { DIVERenderer } from "../renderer/Renderer.ts";
 import DIVEOrbitControls from "../controls/OrbitControls.ts";
 import { Vector3Like } from "three";
 

--- a/src/mediacreator/__test__/MediaCreator.test.ts
+++ b/src/mediacreator/__test__/MediaCreator.test.ts
@@ -1,5 +1,5 @@
 import DIVEMediaCreator from '../MediaCreator';
-import DIVERenderer from '../../renderer/Renderer';
+import { DIVERenderer } from '../../renderer/Renderer';
 import DIVEScene from '../../scene/Scene';
 import DIVEPerspectiveCamera, { DIVEPerspectiveCameraDefaultSettings } from '../../camera/PerspectiveCamera';
 import { COMPov } from '../../com';
@@ -71,14 +71,16 @@ jest.mock('../../controls/OrbitControls', () => {
 });
 
 jest.mock('../../renderer/Renderer', () => {
-    return jest.fn(function () {
-        this.domElement = {
-            toDataURL: mock_toDataURL,
-        }
-        this.render = mock_render;
-        this.OnResize = jest.fn();
-        return this;
-    });
+    return {
+        DIVERenderer: jest.fn(function () {
+            this.domElement = {
+                toDataURL: mock_toDataURL,
+            }
+            this.render = mock_render;
+            this.OnResize = jest.fn();
+            return this;
+        })
+    }
 });
 
 let mediaCreator: DIVEMediaCreator;

--- a/src/mediacreator/__test__/MediaCreator.test.ts
+++ b/src/mediacreator/__test__/MediaCreator.test.ts
@@ -1,4 +1,4 @@
-import DIVEMediaCreator from '../MediaCreator';
+import { DIVEMediaCreator } from '../MediaCreator';
 import { DIVERenderer } from '../../renderer/Renderer';
 import DIVEScene from '../../scene/Scene';
 import DIVEPerspectiveCamera, { DIVEPerspectiveCameraDefaultSettings } from '../../camera/PerspectiveCamera';

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -52,6 +52,12 @@ export default class DIVERenderer extends WebGLRenderer {
         this.debug.checkShaderErrors = false;
     }
 
+    // Stops renderings and disposes the renderer.
+    public Dispose(): void {
+        this.StopRenderer();
+        this.dispose();
+    }
+
     // Starts the renderer with the given scene and camera.
     public StartRenderer(scene: Scene, cam: Camera): void {
         this.setAnimationLoop(() => { this.internal_render(scene, cam) });

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -26,7 +26,7 @@ export const DIVERendererDefaultSettings: DIVERendererSettings = {
  * @module
  */
 
-export default class DIVERenderer extends WebGLRenderer {
+export class DIVERenderer extends WebGLRenderer {
     // basic functionality members
     private paused: boolean = false;
     private running: boolean = false;

--- a/src/renderer/__test__/Renderer.test.ts
+++ b/src/renderer/__test__/Renderer.test.ts
@@ -1,6 +1,6 @@
-import DIVEPerspectiveCamera from '../../camera/PerspectiveCamera';
-import DIVEScene from '../../scene/Scene';
-import DIVERenderer, { DIVERendererDefaultSettings } from '../Renderer';
+import type DIVEPerspectiveCamera from '../../camera/PerspectiveCamera';
+import type DIVEScene from '../../scene/Scene';
+import { DIVERenderer, DIVERendererDefaultSettings } from '../Renderer';
 
 /**
  * @jest-environment jsdom

--- a/src/renderer/__test__/Renderer.test.ts
+++ b/src/renderer/__test__/Renderer.test.ts
@@ -20,6 +20,7 @@ jest.mock('three', () => {
                     position: 'absolute',
                 },
             };
+            this.dispose = jest.fn();
             this.debug = {
                 checkShaderErrors: true,
             };
@@ -43,12 +44,20 @@ let renderer: DIVERenderer;
 describe('dive/renderer/DIVERenderer', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        renderer = new DIVERenderer(DIVERendererDefaultSettings);
+        renderer = new DIVERenderer();
     });
 
     it('should instantiate', () => {
         expect(renderer).toBeDefined();
-        renderer = new DIVERenderer();
+    });
+
+    it('should instantiate with settings parameter', () => {
+        renderer = new DIVERenderer(DIVERendererDefaultSettings);
+        expect(renderer).toBeDefined();
+    });
+
+    it('should dispose', () => {
+        renderer.Dispose();
     });
 
     it('should start render', () => {

--- a/src/scene/Scene.ts
+++ b/src/scene/Scene.ts
@@ -19,6 +19,8 @@ export default class DIVEScene extends Scene {
     constructor() {
         super();
 
+        this.background = new Color(0xffffff);
+
         this.root = new DIVERoot();
         this.add(this.root);
     }

--- a/src/scene/Scene.ts
+++ b/src/scene/Scene.ts
@@ -1,5 +1,5 @@
-import { Color, ColorRepresentation, Object3D, Scene } from 'three';
-import { COMModel, COMEntity } from '../com/types';
+import { Color, Scene, type Box3, type ColorRepresentation, type Object3D } from 'three';
+import { type COMModel, type COMEntity } from '../com/types';
 import DIVERoot from './root/Root';
 
 /**
@@ -27,6 +27,10 @@ export default class DIVEScene extends Scene {
 
     public SetBackground(color: ColorRepresentation): void {
         this.background = new Color(color);
+    }
+
+    public ComputeSceneBB(): Box3 {
+        return this.Root.ComputeSceneBB();
     }
 
     public GetSceneObject(object: Partial<COMEntity>): Object3D | undefined {

--- a/src/scene/__test__/Scene.test.ts
+++ b/src/scene/__test__/Scene.test.ts
@@ -17,6 +17,7 @@ jest.mock('../root/Root', () => {
         this.PlaceOnFloor = mock_PlaceOnFloor;
         this.GetSceneObject = mock_GetSceneObject;
         this.removeFromParent = jest.fn();
+        this.ComputeSceneBB = jest.fn();
         return this;
     });
 });
@@ -36,6 +37,11 @@ describe('dive/scene/DIVEScene', () => {
         const scene = new DIVEScene();
         scene.SetBackground(0x123456);
         expect((scene.background as Color).getHex()).toBe(0x123456);
+    });
+
+    it('should ComputeSceneBB', () => {
+        const scene = new DIVEScene();
+        expect(() => scene.ComputeSceneBB()).not.toThrow();
     });
 
     it('should add object', () => {

--- a/src/scene/root/Root.ts
+++ b/src/scene/root/Root.ts
@@ -1,4 +1,4 @@
-import { Object3D } from "three";
+import { Box3, Object3D } from "three";
 import DIVELightRoot from "./lightroot/LightRoot.ts";
 import DIVEModelRoot from "./modelroot/ModelRoot.ts";
 import { COMLight, COMModel, COMEntity } from "../../com/types.ts";
@@ -37,6 +37,16 @@ export default class DIVERoot extends Object3D {
         this.add(this.floor);
         this.grid = new DIVEGrid();
         this.add(this.grid);
+    }
+
+    public ComputeSceneBB(): Box3 {
+        const bb = new Box3();
+        this.modelRoot.traverse((object: Object3D) => {
+            if ('isObject3D' in object) {
+                bb.expandByObject(object);
+            }
+        });
+        return bb;
     }
 
     public GetSceneObject(object: Partial<COMEntity>): Object3D | undefined {

--- a/src/scene/root/__test__/Root.test.ts
+++ b/src/scene/root/__test__/Root.test.ts
@@ -1,5 +1,6 @@
-import { COMLight, COMModel, COMPov } from '../../../com';
 import DIVERoot from '../Root';
+import { type Vector3, type Object3D } from 'three';
+import { type COMLight, type COMModel, type COMPov } from '../../../com';
 
 const mock_UpdateLight = jest.fn();
 const mock_UpdateModel = jest.fn();
@@ -8,6 +9,62 @@ const mock_GetModel = jest.fn();
 const mock_DeleteLight = jest.fn();
 const mock_DeleteModel = jest.fn();
 const mock_PlaceOnFloor = jest.fn();
+
+jest.mock('three', () => {
+    return {
+        Box3: jest.fn(() => {
+            return {
+                expandByObject: jest.fn(),
+                setFromObject: jest.fn(),
+                applyMatrix4: jest.fn(),
+                union: jest.fn(),
+                isEmpty: jest.fn(),
+                getCenter: jest.fn(),
+                getSize: jest.fn(),
+                getBoundingSphere: jest.fn(),
+            };
+        }),
+        Object3D: jest.fn(function () {
+            this.clear = jest.fn();
+            this.color = {};
+            this.intensity = 0;
+            this.layers = {
+                mask: 0,
+            };
+            this.shadow = {
+                radius: 0,
+                mapSize: { width: 0, height: 0 },
+                bias: 0,
+                camera: {
+                    near: 0,
+                    far: 0,
+                    fov: 0,
+                },
+            }
+            this.add = jest.fn();
+            this.userData = {};
+            this.rotation = {
+                x: 0,
+                y: 0,
+                z: 0,
+                setFromVector3: jest.fn(),
+            };
+            this.scale = {
+                x: 1,
+                y: 1,
+                z: 1,
+                set: jest.fn(),
+            };
+            this.localToWorld = (vec3: Vector3) => {
+                return vec3;
+            };
+            this.traverse = jest.fn((callback) => {
+                callback(this.children[0])
+            });
+            return this;
+        }),
+    }
+});
 
 jest.mock('../../../primitive/floor/Floor', () => {
     return jest.fn(function () {
@@ -52,6 +109,9 @@ jest.mock('../modelroot/ModelRoot', () => {
         this.PlaceOnFloor = mock_PlaceOnFloor;
         this.GetModel = mock_GetModel;
         this.removeFromParent = jest.fn();
+        this.traverse = jest.fn((callback: (object: Object3D) => void) => {
+            callback(this);
+        });
         return this;
     });
 });
@@ -64,7 +124,7 @@ describe('DIVE/scene/root/DIVERoot', () => {
     it('should instantiate', () => {
         const root = new DIVERoot();
         expect(root).toBeDefined();
-        expect(root.children).toHaveLength(4);
+        expect(root.add).toHaveBeenCalledTimes(4);
     });
 
     it('should have Floor', () => {
@@ -75,6 +135,12 @@ describe('DIVE/scene/root/DIVERoot', () => {
     it('should have Grid', () => {
         const root = new DIVERoot();
         expect(root.Grid).toBeDefined();
+    });
+
+    it('should ComputeSceneBB', () => {
+        const root = new DIVERoot();
+        const bb = root.ComputeSceneBB();
+        expect(bb).toBeDefined();
     });
 
     it('should add object', () => {

--- a/src/toolbox/BaseTool.ts
+++ b/src/toolbox/BaseTool.ts
@@ -13,7 +13,7 @@ export type DraggableEvent = {
 }
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-export default abstract class DIVEBaseTool {
+export abstract class DIVEBaseTool {
     readonly POINTER_DRAG_THRESHOLD: number = 0.001;
 
     public name: string;

--- a/src/toolbox/Toolbox.ts
+++ b/src/toolbox/Toolbox.ts
@@ -3,7 +3,7 @@ import type DIVEScene from "../scene/Scene.ts";
 import { type DIVEBaseTool } from "./BaseTool.ts";
 import { type DIVESelectTool } from "./select/SelectTool.ts";
 
-type ToolType = 'select' | 'none';
+export type ToolType = 'select' | 'none';
 
 /**
  * A Toolbox to activate and deactivate tools to use with the pointer.

--- a/src/toolbox/Toolbox.ts
+++ b/src/toolbox/Toolbox.ts
@@ -1,7 +1,9 @@
-import DIVEOrbitControls from "../controls/OrbitControls.ts";
-import DIVEScene from "../scene/Scene.ts";
-import DIVEBaseTool from "./BaseTool.ts";
-import DIVESelectTool from "./select/SelectTool.ts";
+import type DIVEOrbitControls from "../controls/OrbitControls.ts";
+import type DIVEScene from "../scene/Scene.ts";
+import { type DIVEBaseTool } from "./BaseTool.ts";
+import { type DIVESelectTool } from "./select/SelectTool.ts";
+
+type ToolType = 'select' | 'none';
 
 /**
  * A Toolbox to activate and deactivate tools to use with the pointer.
@@ -12,51 +14,51 @@ import DIVESelectTool from "./select/SelectTool.ts";
 export default class DIVEToolbox {
     public static readonly DefaultTool = 'select';
 
-    private activeTool: DIVEBaseTool;
+    private _scene: DIVEScene;
+    private _controller: DIVEOrbitControls;
 
-    private selectTool: DIVESelectTool;
+    private _activeTool: DIVEBaseTool | null;
 
-    private removeListenersCallback: () => void = () => { };
+    private _selectTool: DIVESelectTool | null;
+    public get selectTool(): DIVESelectTool {
+        if (!this._selectTool) {
+            const DIVESelectTool = require('./select/SelectTool.ts').DIVESelectTool as typeof import('./select/SelectTool.ts').DIVESelectTool;
+            this._selectTool = new DIVESelectTool(this._scene, this._controller);
+        }
+        return this._selectTool;
+    }
 
     constructor(scene: DIVEScene, controller: DIVEOrbitControls) {
-        this.selectTool = new DIVESelectTool(scene, controller);
+        this._scene = scene;
+        this._controller = controller;
 
-        const pointerMove = this.onPointerMove.bind(this);
-        const pointerDown = this.onPointerDown.bind(this);
-        const pointerUp = this.onPointerUp.bind(this);
-        const wheel = this.onWheel.bind(this);
-
-        controller.domElement.addEventListener('pointermove', pointerMove);
-        controller.domElement.addEventListener('pointerdown', pointerDown);
-        controller.domElement.addEventListener('pointerup', pointerUp);
-        controller.domElement.addEventListener('wheel', wheel);
-
-        this.removeListenersCallback = () => {
-            controller.domElement.removeEventListener('pointermove', pointerMove);
-            controller.domElement.removeEventListener('pointerdown', pointerDown);
-            controller.domElement.removeEventListener('pointerup', pointerUp);
-            controller.domElement.removeEventListener('wheel', wheel);
-        };
+        // toolset
+        this._selectTool = null;
 
         // default tool
-        this.activeTool = this.selectTool;
-        this.activeTool.Activate();
+        this._activeTool = null;
     }
 
     public dispose(): void {
-        this.removeListenersCallback();
+        this.removeEventListeners();
     }
 
-    public GetActiveTool(): DIVEBaseTool {
-        return this.activeTool;
+    public GetActiveTool(): DIVEBaseTool | null {
+        return this._activeTool;
     }
 
-    public UseTool(tool: string): void {
-        this.activeTool.Deactivate();
+    public UseTool(tool: ToolType): void {
+        this._activeTool?.Deactivate();
         switch (tool) {
             case "select": {
+                this.addEventListeners();
                 this.selectTool.Activate();
-                this.activeTool = this.selectTool;
+                this._activeTool = this.selectTool;
+                break;
+            }
+            case "none": {
+                this.removeEventListeners();
+                this._activeTool = null;
                 break;
             }
             default: {
@@ -74,18 +76,32 @@ export default class DIVEToolbox {
     }
 
     public onPointerMove(e: PointerEvent): void {
-        this.activeTool.onPointerMove(e);
+        this._activeTool?.onPointerMove(e);
     }
 
     public onPointerDown(e: PointerEvent): void {
-        this.activeTool.onPointerDown(e);
+        this._activeTool?.onPointerDown(e);
     }
 
     public onPointerUp(e: PointerEvent): void {
-        this.activeTool.onPointerUp(e);
+        this._activeTool?.onPointerUp(e);
     }
 
     public onWheel(e: WheelEvent): void {
-        this.activeTool.onWheel(e);
+        this._activeTool?.onWheel(e);
+    }
+
+    private addEventListeners(): void {
+        this._controller.domElement.addEventListener('pointermove', (e) => this.onPointerMove(e));
+        this._controller.domElement.addEventListener('pointerdown', (e) => this.onPointerDown(e));
+        this._controller.domElement.addEventListener('pointerup', (e) => this.onPointerUp(e));
+        this._controller.domElement.addEventListener('wheel', (e) => this.onWheel(e));
+    }
+
+    private removeEventListeners(): void {
+        this._controller.domElement.removeEventListener('pointermove', (e) => this.onPointerMove(e));
+        this._controller.domElement.removeEventListener('pointerdown', (e) => this.onPointerDown(e));
+        this._controller.domElement.removeEventListener('pointerup', (e) => this.onPointerUp(e));
+        this._controller.domElement.removeEventListener('wheel', (e) => this.onWheel(e));
     }
 }

--- a/src/toolbox/Toolbox.ts
+++ b/src/toolbox/Toolbox.ts
@@ -39,7 +39,7 @@ export default class DIVEToolbox {
         this._activeTool = null;
     }
 
-    public dispose(): void {
+    public Dispose(): void {
         this.removeEventListeners();
     }
 

--- a/src/toolbox/__test__/BaseTool.test.ts
+++ b/src/toolbox/__test__/BaseTool.test.ts
@@ -1,11 +1,10 @@
 
+import { DIVEBaseTool } from '../BaseTool';
+import type DIVEOrbitControls from '../../controls/OrbitControls';
+import type DIVEScene from '../../scene/Scene';
 import { type Object3D, type Vector3 } from 'three';
-import DIVEOrbitControls from '../../controls/OrbitControls';
-import DIVEScene from '../../scene/Scene';
-import DIVEBaseTool from '../BaseTool';
-import DIVEToolbox from '../Toolbox';
 import { type DIVEHoverable } from '../../interface/Hoverable';
-import { DIVEDraggable } from '../../interface/Draggable';
+import { type DIVEDraggable } from '../../interface/Draggable';
 
 /**
  * @jest-environment jsdom
@@ -47,8 +46,8 @@ describe('dive/toolbox/DIVEBaseTool', () => {
     });
 
     it('should instantiate', () => {
-        const toolBox = new abstractWrapper(mockScene, mockController);
-        expect(toolBox).toBeDefined();
+        const baseTool = new abstractWrapper(mockScene, mockController);
+        expect(baseTool).toBeDefined();
     });
 
     it('should raycast', () => {

--- a/src/toolbox/__test__/BaseTool.test.ts
+++ b/src/toolbox/__test__/BaseTool.test.ts
@@ -50,6 +50,16 @@ describe('dive/toolbox/DIVEBaseTool', () => {
         expect(baseTool).toBeDefined();
     });
 
+    it('should Activate', () => {
+        const baseTool = new abstractWrapper(mockScene, mockController);
+        expect(() => baseTool.Activate()).not.toThrow();
+    });
+
+    it('should Deactivate', () => {
+        const baseTool = new abstractWrapper(mockScene, mockController);
+        expect(() => baseTool.Deactivate()).not.toThrow();
+    });
+
     it('should raycast', () => {
         const toolBox = new abstractWrapper(mockScene, mockController);
         expect(() => toolBox['raycast']()).not.toThrow();
@@ -62,7 +72,24 @@ describe('dive/toolbox/DIVEBaseTool', () => {
         expect(toolBox['_pointerAnyDown']).toBeDefined();
         expect(toolBox['_pointerAnyDown']).toBe(false);
 
+        toolBox['_pointerPrimaryDown'] = false;
+        toolBox['_pointerMiddleDown'] = false;
+        toolBox['_pointerSecondaryDown'] = false;
+        expect(toolBox['_pointerAnyDown']).toBe(false);
+
         toolBox['_pointerPrimaryDown'] = true;
+        toolBox['_pointerMiddleDown'] = false;
+        toolBox['_pointerSecondaryDown'] = false;
+        expect(toolBox['_pointerAnyDown']).toBe(true);
+
+        toolBox['_pointerPrimaryDown'] = false;
+        toolBox['_pointerMiddleDown'] = true;
+        toolBox['_pointerSecondaryDown'] = false;
+        expect(toolBox['_pointerAnyDown']).toBe(true);
+
+        toolBox['_pointerPrimaryDown'] = false;
+        toolBox['_pointerMiddleDown'] = false;
+        toolBox['_pointerSecondaryDown'] = true;
         expect(toolBox['_pointerAnyDown']).toBe(true);
     });
 
@@ -387,8 +414,18 @@ describe('dive/toolbox/DIVEBaseTool', () => {
         expect(() => toolBox.onDrag({} as PointerEvent)).not.toThrow();
     });
 
+    it('should execute onCLick correctly', () => {
+        const toolBox = new abstractWrapper(mockScene, mockController);
+        expect(() => toolBox.onClick({} as PointerEvent)).not.toThrow();
+    });
+
     it('should execute onDragEnd correctly', () => {
         const toolBox = new abstractWrapper(mockScene, mockController);
         expect(() => toolBox.onDragEnd({} as PointerEvent)).not.toThrow();
+    });
+
+    it('should execute onWheel correctly', () => {
+        const toolBox = new abstractWrapper(mockScene, mockController);
+        expect(() => toolBox.onWheel({} as WheelEvent)).not.toThrow();
     });
 });

--- a/src/toolbox/__test__/Toolbox.test.ts
+++ b/src/toolbox/__test__/Toolbox.test.ts
@@ -1,6 +1,6 @@
-import DIVEOrbitControls from '../../controls/OrbitControls';
-import DIVEScene from '../../scene/Scene';
-import DIVEToolbox from '../Toolbox';
+import DIVEToolbox, { type ToolType } from '../Toolbox';
+import type DIVEOrbitControls from '../../controls/OrbitControls';
+import type DIVEScene from '../../scene/Scene';
 
 /**
  * @jest-environment jsdom
@@ -21,27 +21,20 @@ const mock_Canvas = {
     offsetTop: 0,
 };
 
-const mock_Activate = jest.fn();
-const mock_Deactivate = jest.fn();
-const mock_onPointerDown = jest.fn();
-const mock_onPointerMove = jest.fn();
-const mock_onPointerUp = jest.fn();
-const mock_onWheel = jest.fn();
-const mock_SetGizmoMode = jest.fn();
-const mock_SetGizmoVisibility = jest.fn();
-
 jest.mock('../select/SelectTool.ts', () => {
-    return jest.fn(function () {
-        this.Activate = mock_Activate;
-        this.Deactivate = mock_Deactivate;
-        this.onPointerDown = mock_onPointerDown;
-        this.onPointerMove = mock_onPointerMove;
-        this.onPointerUp = mock_onPointerUp;
-        this.onWheel = mock_onWheel;
-        this.SetGizmoMode = mock_SetGizmoMode;
-        this.SetGizmoVisibility = mock_SetGizmoVisibility;
-        return this;
-    });
+    return {
+        DIVESelectTool: jest.fn(function () {
+            this.Activate = jest.fn();
+            this.Deactivate = jest.fn();
+            this.onPointerDown = jest.fn();
+            this.onPointerMove = jest.fn();
+            this.onPointerUp = jest.fn();
+            this.onWheel = jest.fn();
+            this.SetGizmoMode = jest.fn();
+            this.SetGizmoVisibility = jest.fn();
+            return this;
+        })
+    }
 });
 
 const mockController = {
@@ -58,8 +51,6 @@ describe('dive/toolbox/DIVEToolBox', () => {
     it('should instantiate', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
         expect(toolBox).toBeDefined();
-        expect(mock_Activate).toHaveBeenCalledTimes(1);
-        expect(mock_addEventListener).toHaveBeenCalled();
     });
 
     it('should dispose', () => {
@@ -70,40 +61,46 @@ describe('dive/toolbox/DIVEToolBox', () => {
 
     it('should throw with incorrect tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        expect(() => toolBox.UseTool('not a real tool')).toThrow();
-        expect(mock_Deactivate).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.UseTool('not a real tool' as unknown as ToolType)).toThrow();
+    });
+
+    it('should use no tool', () => {
+        const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
+        expect(() => toolBox.UseTool('select')).not.toThrow();
+        expect(() => toolBox.UseTool('none')).not.toThrow();
     });
 
     it('should use select tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        expect(mock_Activate).toHaveBeenCalledTimes(1);
-        toolBox.UseTool(DIVEToolbox.DefaultTool);
-        expect(mock_Deactivate).toHaveBeenCalledTimes(1);
-        expect(mock_Activate).toHaveBeenCalledTimes(2);
+        expect(() => toolBox.UseTool(DIVEToolbox.DefaultTool)).not.toThrow();
     });
 
     it('should execute pointer down event on tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.onPointerDown({ type: 'pointerdown' } as PointerEvent);
-        expect(mock_onPointerDown).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.onPointerDown({ type: 'pointerdown' } as PointerEvent)).not.toThrow();
+        expect(() => toolBox.UseTool('select')).not.toThrow();
+        expect(() => toolBox.onPointerDown({ type: 'pointerdown' } as PointerEvent)).not.toThrow();
     });
 
     it('should execute pointer move event on tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.onPointerMove({ type: 'pointermove' } as PointerEvent);
-        expect(mock_onPointerMove).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.onPointerMove({ type: 'pointermove' } as PointerEvent)).not.toThrow();
+        expect(() => toolBox.UseTool('select')).not.toThrow();
+        expect(() => toolBox.onPointerMove({ type: 'pointermove' } as PointerEvent)).not.toThrow();
     });
 
     it('should execute pointer up event on tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.onPointerUp({ type: 'pointerup' } as PointerEvent);
-        expect(mock_onPointerUp).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.onPointerUp({ type: 'pointerup' } as PointerEvent)).not.toThrow();
+        expect(() => toolBox.UseTool('select')).not.toThrow();
+        expect(() => toolBox.onPointerUp({ type: 'pointerup' } as PointerEvent)).not.toThrow();
     });
 
     it('should execute wheel event on tool', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.onWheel({ type: 'wheel' } as WheelEvent);
-        expect(mock_onWheel).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.onWheel({ type: 'wheel' } as WheelEvent)).not.toThrow();
+        expect(() => toolBox.UseTool('select')).not.toThrow();
+        expect(() => toolBox.onWheel({ type: 'wheel' } as WheelEvent)).not.toThrow();
     });
 
     it('should get active tool', () => {
@@ -113,13 +110,11 @@ describe('dive/toolbox/DIVEToolBox', () => {
 
     it('should set gizmo mode', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.SetGizmoMode('translate');
-        expect(mock_SetGizmoMode).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.SetGizmoMode('translate')).not.toThrow();
     });
 
     it('should set gizmo active', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.SetGizmoVisibility(true);
-        expect(mock_SetGizmoVisibility).toHaveBeenCalledTimes(1);
+        expect(() => toolBox.SetGizmoVisibility(true)).not.toThrow();
     });
 });

--- a/src/toolbox/__test__/Toolbox.test.ts
+++ b/src/toolbox/__test__/Toolbox.test.ts
@@ -55,7 +55,7 @@ describe('dive/toolbox/DIVEToolBox', () => {
 
     it('should dispose', () => {
         const toolBox = new DIVEToolbox({} as DIVEScene, mockController);
-        toolBox.dispose();
+        toolBox.Dispose();
         expect(mock_removeEventListener).toHaveBeenCalled();
     });
 

--- a/src/toolbox/select/SelectTool.ts
+++ b/src/toolbox/select/SelectTool.ts
@@ -1,9 +1,14 @@
-import { Object3D } from "three";
-import { DIVESelectable, findSelectableInterface } from "../../interface/Selectable.ts";
+import { type Object3D } from "three";
 import DIVEScene from "../../scene/Scene.ts";
-import { DIVEMoveable } from "../../interface/Moveable.ts";
-import DIVEOrbitControls from "../../controls/OrbitControls.ts";
 import DIVETransformTool from "../transform/TransformTool.ts";
+import type DIVEOrbitControls from "../../controls/OrbitControls.ts";
+import { type DIVESelectable, findSelectableInterface } from "../../interface/Selectable.ts";
+import { type DIVEMoveable } from "../../interface/Moveable.ts";
+import { type DIVEBaseTool } from "../BaseTool.ts";
+
+export const isSelectTool = (tool: DIVEBaseTool): tool is DIVESelectTool => {
+    return (tool as DIVESelectTool).isSelectTool !== undefined;
+}
 
 export interface DIVEObjectEventMap {
     select: object
@@ -17,7 +22,8 @@ export interface DIVEObjectEventMap {
  * @module
  */
 
-export default class DIVESelectTool extends DIVETransformTool {
+export class DIVESelectTool extends DIVETransformTool {
+    readonly isSelectTool: boolean = true;
 
     constructor(scene: DIVEScene, controller: DIVEOrbitControls) {
         super(scene, controller);

--- a/src/toolbox/select/SelectTool.ts
+++ b/src/toolbox/select/SelectTool.ts
@@ -1,5 +1,5 @@
 import { Object3D } from "three";
-import { DIVESelectable, isSelectable } from "../../interface/Selectable.ts";
+import { DIVESelectable, findSelectableInterface } from "../../interface/Selectable.ts";
 import DIVEScene from "../../scene/Scene.ts";
 import { DIVEMoveable } from "../../interface/Moveable.ts";
 import DIVEOrbitControls from "../../controls/OrbitControls.ts";
@@ -39,10 +39,6 @@ export default class DIVESelectTool extends DIVETransformTool {
         this.DetachGizmo();
     }
 
-    public DetachGizmo(): void {
-        this._gizmo.detach();
-    }
-
     public AttachGizmo(selectable: DIVESelectable): void {
         if ('isMoveable' in selectable) {
             const movable = selectable as (Object3D & DIVESelectable & DIVEMoveable);
@@ -51,11 +47,15 @@ export default class DIVESelectTool extends DIVETransformTool {
         }
     }
 
+    public DetachGizmo(): void {
+        this._gizmo.detach();
+    }
+
     public onClick(e: PointerEvent): void {
         super.onClick(e);
 
-        const first = this._raycaster.intersectObjects(this._scene.Root.children, true).filter((intersect) => intersect.object.visible )[0];
-        const selectable = this.findSelectableInterface(first?.object);
+        const first = this._raycaster.intersectObjects(this._scene.Root.children, true).filter((intersect) => intersect.object.visible)[0];
+        const selectable = findSelectableInterface(first?.object);
 
         // if nothing is hit
         if (!first || !selectable) {
@@ -76,22 +76,5 @@ export default class DIVESelectTool extends DIVETransformTool {
 
         // select clicked object
         this.Select(selectable);
-    }
-
-    private findSelectableInterface(child: Object3D): (Object3D & DIVESelectable) | undefined {
-        if (child === undefined) return undefined;
-
-        if (child.parent === null) {
-            // in this case it is the scene itself
-            return undefined;
-        }
-
-        if (isSelectable(child)) {
-            // in this case it is the Selectable
-            return child;
-        }
-
-        // search recursively in parent
-        return this.findSelectableInterface(child.parent);
     }
 }

--- a/src/toolbox/select/__test__/SelectTool.test.ts
+++ b/src/toolbox/select/__test__/SelectTool.test.ts
@@ -1,10 +1,11 @@
-import DIVESelectTool from '../SelectTool';
+import { DIVESelectTool, isSelectTool } from '../SelectTool';
 import DIVEScene from '../../../scene/Scene';
 import DIVEOrbitControls from '../../../controls/OrbitControls';
-import DIVEPerspectiveCamera from '../../../camera/PerspectiveCamera';
-import DIVERenderer, { DIVERendererDefaultSettings } from '../../../renderer/Renderer';
-import { DIVESelectable, isSelectable } from '../../../interface/Selectable';
+import { DIVERenderer, DIVERendererDefaultSettings } from '../../../renderer/Renderer';
+import { DIVESelectable } from '../../../interface/Selectable';
+import type DIVEPerspectiveCamera from '../../../camera/PerspectiveCamera';
 import { type Object3D } from 'three';
+import { type DIVEBaseTool } from '../../BaseTool';
 
 jest.mock('../../../renderer/Renderer', () => {
     return jest.fn(function () {
@@ -109,11 +110,19 @@ jest.mock('three/examples/jsm/Addons.js', () => {
 });
 
 const mockCamera: DIVEPerspectiveCamera = {} as DIVEPerspectiveCamera;
-const mockRenderer: DIVERenderer = new DIVERenderer(DIVERendererDefaultSettings);
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+} as unknown as DIVERenderer;
 const mockScene: DIVEScene = new DIVEScene();
 const mockController: DIVEOrbitControls = new DIVEOrbitControls(mockCamera, mockRenderer);
 
 describe('dive/toolbox/select/DIVESelectTool', () => {
+    it('should test if it is SelectTool', () => {
+        const selectTool = { isSelectTool: true } as unknown as DIVEBaseTool;
+        expect(isSelectTool(selectTool)).toBeDefined();
+    });
+
     it('should instantiate', () => {
         const selectTool = new DIVESelectTool(mockScene, mockController);
         expect(selectTool).toBeDefined();
@@ -132,13 +141,13 @@ describe('dive/toolbox/select/DIVESelectTool', () => {
 
     it('should execute onClick with hit', () => {
         mock_intersectObjects.mockReturnValueOnce(
-          [{
-              object: {
-                  uuid: 'test',
-                  visible: true,
-                  parent: { name: 'this is the test scene root!!!', parent: null }
-              }
-          }]
+            [{
+                object: {
+                    uuid: 'test',
+                    visible: true,
+                    parent: { name: 'this is the test scene root!!!', parent: null }
+                }
+            }]
         );
         const selectTool = new DIVESelectTool(mockScene, mockController);
         expect(() => selectTool.onClick({ offsetX: 0, offsetY: 0 } as PointerEvent)).not.toThrow();

--- a/src/toolbox/transform/TransformTool.ts
+++ b/src/toolbox/transform/TransformTool.ts
@@ -1,8 +1,12 @@
-import DIVEBaseTool from "../BaseTool.ts";
+import { DIVEBaseTool } from "../BaseTool.ts";
 import DIVEScene from "../../scene/Scene.ts";
 import DIVEOrbitControls from "../../controls/OrbitControls.ts";
 import { TransformControls } from "three/examples/jsm/Addons";
 import { type DIVEMoveable } from "../../interface/Moveable.ts";
+
+export const isTransformTool = (tool: DIVEBaseTool): tool is DIVETransformTool => {
+    return (tool as DIVETransformTool).isTransformTool !== undefined;
+}
 
 export interface DIVEObjectEventMap {
     select: object
@@ -17,6 +21,8 @@ export interface DIVEObjectEventMap {
  */
 
 export default class DIVETransformTool extends DIVEBaseTool {
+    readonly isTransformTool: boolean = true;
+
     protected _gizmo: TransformControls;
 
     constructor(scene: DIVEScene, controller: DIVEOrbitControls) {

--- a/src/toolbox/transform/__test__/TransformTool.test.ts
+++ b/src/toolbox/transform/__test__/TransformTool.test.ts
@@ -1,10 +1,9 @@
-import DIVETransformTool from '../TransformTool';
+import DIVETransformTool, { isTransformTool } from '../TransformTool';
 import DIVEScene from '../../../scene/Scene';
 import DIVEOrbitControls from '../../../controls/OrbitControls';
 import DIVEPerspectiveCamera from '../../../camera/PerspectiveCamera';
-import DIVERenderer, { DIVERendererDefaultSettings } from '../../../renderer/Renderer';
-import { type Object3D } from 'three';
-import { type DIVEMoveable } from '../../../interface/Moveable';
+import { DIVERenderer } from '../../../renderer/Renderer';
+import { type DIVEBaseTool } from '../../BaseTool';
 
 jest.mock('../../../renderer/Renderer', () => {
     return jest.fn(function () {
@@ -112,11 +111,29 @@ jest.mock('three/examples/jsm/Addons.js', () => {
 });
 
 const mockCamera: DIVEPerspectiveCamera = {} as DIVEPerspectiveCamera;
-const mockRenderer: DIVERenderer = new DIVERenderer(DIVERendererDefaultSettings);
+const mockRenderer = {
+    render: jest.fn(),
+    OnResize: jest.fn(),
+    getViewport: jest.fn(),
+    setViewport: jest.fn(),
+    AddPreRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    AddPostRenderCallback: jest.fn((callback) => {
+        callback();
+    }),
+    RemovePreRenderCallback: jest.fn(),
+    RemovePostRenderCallback: jest.fn(),
+} as unknown as DIVERenderer;
 const mockScene: DIVEScene = new DIVEScene();
 const mockController: DIVEOrbitControls = new DIVEOrbitControls(mockCamera, mockRenderer);
 
 describe('dive/toolbox/select/DIVETransformTool', () => {
+    it('should test if it is SelectTool', () => {
+        const selectTool = { isTransformTool: true } as unknown as DIVEBaseTool;
+        expect(isTransformTool(selectTool)).toBeDefined();
+    });
+
     it('should instantiate', () => {
         const transformTool = new DIVETransformTool(mockScene, mockController);
         expect(transformTool).toBeDefined();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We want to support a very easy method to just view a model.

### 2. What does this change do, exactly?
Introduces QuickView (static) method to DIVE which loads a model and displays it in a standard setup. To make that work, we made some parts of the framework optional while loading up to reduce the workload as far as possible.

We also added some functionalities like using no tool (to support no interaction in QuickView) with the according tests. In addition to that we added disposing to DIVE in general (``dive.Dispose()``).

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.