### PR TITLE
add primitives to GET_ALL_SCENE_DATA action

### DIFF
--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -239,7 +239,7 @@ export class DIVECommunication {
             lights: Array.from(this.registered.values()).filter((object) => object.entityType === 'light') as COMLight[],
             objects: Array.from(this.registered.values()).filter((object) => object.entityType === 'model') as COMModel[],
             cameras: Array.from(this.registered.values()).filter((object) => object.entityType === 'pov') as COMPov[],
-            primitives: Array.from(this.registered.values()).filter((object) => object.entityType === 'primitives') as COMPrimitive[],
+            primitives: Array.from(this.registered.values()).filter((object) => object.entityType === 'primitive') as COMPrimitive[],
         };
         Object.assign(payload, sceneData);
         return sceneData;

--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -4,7 +4,7 @@ import { isSelectTool } from "../toolbox/select/SelectTool.ts";
 
 // type imports
 import { type Color, type MeshStandardMaterial } from "three";
-import { type COMLight, type COMModel, type COMEntity, type COMPov } from "./types";
+import { type COMLight, type COMModel, type COMEntity, type COMPov, type COMPrimitive } from "./types";
 import { type DIVEScene } from "../scene/Scene.ts";
 import type DIVEToolbox from "../toolbox/Toolbox.ts";
 import type DIVEOrbitControls from "../controls/OrbitControls.ts";
@@ -239,6 +239,7 @@ export class DIVECommunication {
             lights: Array.from(this.registered.values()).filter((object) => object.entityType === 'light') as COMLight[],
             objects: Array.from(this.registered.values()).filter((object) => object.entityType === 'model') as COMModel[],
             cameras: Array.from(this.registered.values()).filter((object) => object.entityType === 'pov') as COMPov[],
+            primitives: Array.from(this.registered.values()).filter((object) => object.entityType === 'primitives') as COMPrimitive[],
         };
         Object.assign(payload, sceneData);
         return sceneData;

--- a/src/com/__test__/Communication.test.ts
+++ b/src/com/__test__/Communication.test.ts
@@ -25,7 +25,7 @@ import type { DIVEScene } from '../../scene/Scene';
 import type DIVEToolbox from '../../toolbox/Toolbox';
 import type DIVEOrbitControls from '../../controls/OrbitControls';
 import { type DIVERenderer } from '../../renderer/Renderer';
-import { type COMEntity, type COMEntityType, type COMLight, type COMModel, type COMPov } from '../types';
+import { type COMEntity, type COMEntityType, type COMLight, type COMModel, type COMPov, type COMPrimitive } from '../types';
 import { type DIVESceneObject } from '../../types';
 
 jest.mock('three/src/math/MathUtils', () => {
@@ -547,6 +547,7 @@ describe('dive/communication/DIVECommunication', () => {
                 parent: null,
                 uri: "https://threejs.org/examples/models/gltf/LittlestTokyo.glb",
             }],
+            primitives: [],
             spotmarks: [],
             userCamera: {
                 position: { x: 1, y: 2, z: 3 },

--- a/src/com/actions/scene/getallscenedata.ts
+++ b/src/com/actions/scene/getallscenedata.ts
@@ -14,8 +14,8 @@ type SceneData = {
     spotmarks: object[],
     lights: COMLight[],
     objects: COMModel[],
-    cameras: COMPov[],,
-    primitives: COMPrimitive[];
+    cameras: COMPov[],
+    primitives: COMPrimitive[],
 };
 
 export default interface GET_ALL_SCENE_DATA {

--- a/src/com/actions/scene/getallscenedata.ts
+++ b/src/com/actions/scene/getallscenedata.ts
@@ -1,5 +1,5 @@
 import { Vector3Like } from "three";
-import { COMLight, COMModel, COMPov } from "../../types";
+import { COMLight, COMModel, COMPov, COMPrimitive } from "../../types";
 
 type SceneData = {
     name: string,

--- a/src/com/actions/scene/getallscenedata.ts
+++ b/src/com/actions/scene/getallscenedata.ts
@@ -14,7 +14,8 @@ type SceneData = {
     spotmarks: object[],
     lights: COMLight[],
     objects: COMModel[],
-    cameras: COMPov[],
+    cameras: COMPov[],,
+    primitives: COMPrimitive[];
 };
 
 export default interface GET_ALL_SCENE_DATA {

--- a/src/com/actions/scene/getallscenedata.ts
+++ b/src/com/actions/scene/getallscenedata.ts
@@ -1,5 +1,5 @@
 import { Vector3Like } from "three";
-import { COMLight, COMModel, COMPov, COMPrimitive } from "../../types";
+import { type COMLight, type COMModel, type COMPov, type COMPrimitive } from "../../types";
 
 type SceneData = {
     name: string,


### PR DESCRIPTION
### 1. Why is this change necessary?
To include primitives data in GET_ALL_SCENE_DATA action.

### 2. What does this change do, exactly?
include primitives data in GET_ALL_SCENE_DATA action.

### 3. Describe each step to reproduce the issue or behaviour.
The Scene cant be saved due to expected scene data from dive is missing primitive data

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.