### PR TITLE
Return groups in all scene data

### DIFF
--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -4,7 +4,7 @@ import { isSelectTool } from "../toolbox/select/SelectTool.ts";
 
 // type imports
 import { type Color, type MeshStandardMaterial } from "three";
-import { type COMLight, type COMModel, type COMEntity, type COMPov, type COMPrimitive } from "./types";
+import { type COMLight, type COMModel, type COMEntity, type COMPov, type COMPrimitive, type COMGroup } from "./types";
 import { type DIVEScene } from "../scene/Scene.ts";
 import type DIVEToolbox from "../toolbox/Toolbox.ts";
 import type DIVEOrbitControls from "../controls/OrbitControls.ts";
@@ -240,6 +240,7 @@ export class DIVECommunication {
             objects: Array.from(this.registered.values()).filter((object) => object.entityType === 'model') as COMModel[],
             cameras: Array.from(this.registered.values()).filter((object) => object.entityType === 'pov') as COMPov[],
             primitives: Array.from(this.registered.values()).filter((object) => object.entityType === 'primitive') as COMPrimitive[],
+            groups: Array.from(this.registered.values()).filter((object) => object.entityType === 'group') as COMGroup[],
         };
         Object.assign(payload, sceneData);
         return sceneData;

--- a/src/com/__test__/Communication.test.ts
+++ b/src/com/__test__/Communication.test.ts
@@ -25,7 +25,7 @@ import type { DIVEScene } from '../../scene/Scene';
 import type DIVEToolbox from '../../toolbox/Toolbox';
 import type DIVEOrbitControls from '../../controls/OrbitControls';
 import { type DIVERenderer } from '../../renderer/Renderer';
-import { type COMEntity, type COMEntityType, type COMLight, type COMModel, type COMPov, type COMPrimitive } from '../types';
+import { type COMGroup, type COMEntity, type COMEntityType, type COMLight, type COMModel, type COMPov, type COMPrimitive } from '../types';
 import { type DIVESceneObject } from '../../types';
 
 jest.mock('three/src/math/MathUtils', () => {
@@ -516,6 +516,14 @@ describe('dive/communication/DIVECommunication', () => {
             color: 'white',
         } as COMLight);
 
+        testCom.PerformAction('ADD_OBJECT', {
+            entityType: "group",
+            id: "group1",
+            position: { x: 0, y: 0, z: 0 },
+            rotation: { x: 0, y: 0, z: 0 },
+            parent: null,
+        } as COMGroup);
+
         const success = testCom.PerformAction('GET_ALL_SCENE_DATA', {});
         expect(success).toStrictEqual({
             backgroundColor: "#ffffff",
@@ -553,6 +561,13 @@ describe('dive/communication/DIVECommunication', () => {
                 position: { x: 1, y: 2, z: 3 },
                 target: { x: 4, y: 5, z: 6 },
             },
+            groups: [{
+                entityType: "group",
+                id: "group1",
+                position: { x: 0, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0 },
+                parent: null,
+            }],
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We need to return groups to save the scene.

### 2. What does this change do, exactly?
Returns groups in GET_ALL_SCENE_DATA call.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.