### PR TITLE
fix placeonfloor function for models and primitives

### DIFF
--- a/src/com/Communication.ts
+++ b/src/com/Communication.ts
@@ -457,6 +457,27 @@ export class DIVECommunication {
         const deletedObject = this.registered.get(payload.id);
         if (!deletedObject) return false;
 
+        // If the object has a parent, detach it first
+        if (deletedObject.parentId) {
+            // First detach from parent group
+            this.setParent({
+                object: { id: deletedObject.id },
+                parent: null,
+            });
+        }
+
+        // If deleting a group, update all children to have no parent
+        if (deletedObject.entityType === 'group') {
+            this.registered.forEach((object) => {
+                if (object.parentId === deletedObject.id) {
+                    this.updateObject({
+                        id: object.id,
+                        parentId: null,
+                    });
+                }
+            });
+        }
+
         // copy object to payload to use later
         Object.assign(payload, deletedObject);
 
@@ -723,6 +744,11 @@ export class DIVECommunication {
         if (payload.parent === null) {
             // detach from current parent
             this.scene.Root.attach(sceneObject);
+            // Update registration to reflect no parent
+            this.updateObject({
+                id: object.id,
+                parentId: null,
+            });
             return true;
         }
 
@@ -735,6 +761,11 @@ export class DIVECommunication {
         if (!parent) {
             // detach from current parent
             this.scene.Root.attach(sceneObject);
+            // Update registration to reflect no parent
+            this.updateObject({
+                id: object.id,
+                parentId: null,
+            });
             return true;
         }
 
@@ -743,11 +774,21 @@ export class DIVECommunication {
         if (!parentObject) {
             // detach from current parent
             this.scene.Root.attach(sceneObject);
+            // Update registration to reflect no parent
+            this.updateObject({
+                id: object.id,
+                parentId: null,
+            });
             return true;
         }
 
         // attach to new parent
         parentObject.attach(sceneObject);
+        // Update registration to reflect new parent
+        this.updateObject({
+            id: object.id,
+            parentId: parent.id,
+        });
         return true;
     }
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -116,8 +116,14 @@ export class DIVEModel extends DIVENode {
         const worldPos = this.getWorldPosition(this._positionWorldBuffer);
         const oldWorldPos = worldPos.clone();
 
-        // calculate the bottom center of the bounding box and set it to world posion
-        worldPos.y = (this._boundingBox.max.y - this._boundingBox.min.y) / 2;
+        // compute the bounding box 
+        this._mesh?.geometry?.computeBoundingBox();
+        const meshBB = this._mesh?.geometry?.boundingBox;
+
+        // subtract the bounding box min y axis value from the world position y value
+        if (meshBB && this._mesh) {
+            worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
+        }
 
         // skip any action when the position did not change
         if (worldPos.y === oldWorldPos.y) return;

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -121,10 +121,8 @@ export class DIVEModel extends DIVENode {
         const meshBB = this._mesh?.geometry?.boundingBox;
 
         // subtract the bounding box min y axis value from the world position y value
-        if (meshBB && this._mesh) {
-            worldPos.y =
-                worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
-        }
+        if (!meshBB || !this._mesh) return;
+        worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
 
         // skip any action when the position did not change
         if (worldPos.y === oldWorldPos.y) return;

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -119,15 +119,11 @@ export class DIVEModel extends DIVENode {
         // compute the bounding box
         this._mesh?.geometry?.computeBoundingBox();
         const meshBB = this._mesh?.geometry?.boundingBox;
-        console.log(meshBB);
+
         // subtract the bounding box min y axis value from the world position y value
         if (meshBB && this._mesh) {
-            console.log(meshBB);
-            console.log(this._mesh);
-            console.log(worldPos.y);
             worldPos.y =
                 worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
-            console.log(worldPos.y);
         }
 
         // skip any action when the position did not change

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -116,13 +116,18 @@ export class DIVEModel extends DIVENode {
         const worldPos = this.getWorldPosition(this._positionWorldBuffer);
         const oldWorldPos = worldPos.clone();
 
-        // compute the bounding box 
+        // compute the bounding box
         this._mesh?.geometry?.computeBoundingBox();
         const meshBB = this._mesh?.geometry?.boundingBox;
-
+        console.log(meshBB);
         // subtract the bounding box min y axis value from the world position y value
         if (meshBB && this._mesh) {
-            worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
+            console.log(meshBB);
+            console.log(this._mesh);
+            console.log(worldPos.y);
+            worldPos.y =
+                worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
+            console.log(worldPos.y);
         }
 
         // skip any action when the position did not change

--- a/src/model/__test__/Model.test.ts
+++ b/src/model/__test__/Model.test.ts
@@ -9,10 +9,9 @@ import {
     MeshStandardMaterial,
     type Texture,
     Color,
+    Object3D,
 } from 'three';
 import { type COMMaterial } from '../../com/types';
-import { isTypeOnlyImportOrExportDeclaration } from 'typescript';
-import { untilNextWrapThresholdCommentRegExp } from 'prettier-plugin-multiline-arrays';
 
 const intersectObjectsMock = jest.fn();
 
@@ -26,43 +25,43 @@ jest.mock('three', () => {
             this.x = x;
             this.y = y;
             this.z = z;
-            this.copy = (vec3: Vector3) => {
+            this.copy = jest.fn((vec3: Vector3) => {
                 this.x = vec3.x;
                 this.y = vec3.y;
                 this.z = vec3.z;
                 return this;
-            };
-            this.set = (x: number, y: number, z: number) => {
+            });
+            this.set = jest.fn((x: number, y: number, z: number) => {
                 this.x = x;
                 this.y = y;
                 this.z = z;
                 return this;
-            };
-            this.multiply = (vec3: Vector3) => {
+            });
+            this.multiply = jest.fn((vec3: Vector3) => {
                 this.x *= vec3.x;
                 this.y *= vec3.y;
                 this.z *= vec3.z;
                 return this;
-            };
-            this.clone = () => {
+            });
+            this.clone = jest.fn(() => {
                 return new Vector3(this.x, this.y, this.z);
-            };
-            this.setY = (y: number) => {
+            });
+            this.setY = jest.fn((y: number) => {
                 this.y = y;
                 return this;
-            };
-            this.add = (vec3: Vector3) => {
+            });
+            this.add = jest.fn((vec3: Vector3) => {
                 this.x += vec3.x;
                 this.y += vec3.y;
                 this.z += vec3.z;
                 return this;
-            };
-            this.sub = (vec3: Vector3) => {
+            });
+            this.sub = jest.fn((vec3: Vector3) => {
                 this.x -= vec3.x;
                 this.y -= vec3.y;
                 this.z -= vec3.z;
                 return this;
-            };
+            });
             return this;
         }),
         Object3D: jest.fn(function () {
@@ -84,14 +83,7 @@ jest.mock('three', () => {
             };
             this.add = jest.fn();
             this.sub = jest.fn();
-            this.children = [
-                {
-                    visible: true,
-                    material: {
-                        color: {},
-                    },
-                },
-            ];
+            this.children = [];
             this.userData = {};
             this.position = new Vector3();
             this.rotation = {
@@ -106,12 +98,14 @@ jest.mock('three', () => {
                 z: 1,
                 set: jest.fn(),
             };
-            this.localToWorld = (vec3: Vector3) => {
+            this.localToWorld = jest.fn((vec3: Vector3) => {
                 return vec3;
-            };
-            this.mesh = new Mesh();
+            });
             this.traverse = jest.fn((callback) => {
-                callback(this.children[0]);
+                callback(this);
+                this.children.forEach((child: Object3D) => {
+                    callback(child);
+                });
             });
             this.getWorldPosition = jest.fn(() => {
                 return this.position.clone();
@@ -137,11 +131,12 @@ jest.mock('three', () => {
             return this;
         }),
         Mesh: jest.fn(function () {
+            this.isMesh = true;
             this.geometry = {
                 computeBoundingBox: jest.fn(),
                 boundingBox: new Box3(),
             };
-            this.material = {};
+            this.material = new MeshStandardMaterial();
             this.castShadow = true;
             this.receiveShadow = true;
             this.layers = {
@@ -150,9 +145,9 @@ jest.mock('three', () => {
             this.updateWorldMatrix = jest.fn();
             this.traverse = jest.fn();
             this.removeFromParent = jest.fn();
-            this.localToWorld = (vec3: Vector3) => {
+            this.localToWorld = jest.fn((vec3: Vector3) => {
                 return vec3;
-            };
+            });
             return this;
         }),
         MeshStandardMaterial: jest.fn(function () {
@@ -182,33 +177,12 @@ jest.mock('../../com/Communication.ts', () => {
     };
 });
 
+const object = new Object3D();
+object.children.push(new Mesh());
+
 const gltf = {
     scene: {
-        isMesh: true,
-        isObject3D: true,
-        parent: null,
-        dispatchEvent: jest.fn(),
-        layers: {
-            mask: 0,
-        },
-        material: {},
-        updateWorldMatrix: jest.fn(),
-        children: [
-            {
-                castShadow: false,
-                receiveShadow: false,
-                layers: {
-                    mask: 0,
-                },
-                children: [],
-                updateWorldMatrix: jest.fn(),
-                isMesh: true,
-            },
-        ],
-        traverse: function (callback: (object: object) => void) {
-            callback(this);
-        },
-        removeFromParent: jest.fn(),
+        ...object,
     },
 } as unknown as GLTF;
 
@@ -245,22 +219,9 @@ describe('dive/model/DIVEModel', () => {
         model.userData.id = 'something';
         model.position.set(0, 4, 0);
 
-        // @ts-ignore
-        model['_mesh'].geometry = {
-            computeBoundingBox: jest.fn(),
-        };
-        // @ts-ignore
-        model['_mesh'].localToWorld = (vec3: Vector3) => {
-            return vec3;
-        };
-        // @ts-ignore
-        model['_mesh']['geometry'].boundingBox = {
-            min: new Vector3(0, -2, 0),
-        };
-        // @ts-ignore
-        model['_mesh'].localToWorld = () => {
-            return new Vector3(0, 2, 0);
-        };
+        jest.spyOn(model['_mesh']!, 'localToWorld').mockReturnValueOnce(
+            new Vector3(0, 2, 0),
+        );
 
         const scene = {
             parent: null,

--- a/src/model/__test__/Model.test.ts
+++ b/src/model/__test__/Model.test.ts
@@ -12,6 +12,7 @@ import {
 } from 'three';
 import { type COMMaterial } from '../../com/types';
 import { isTypeOnlyImportOrExportDeclaration } from 'typescript';
+import { untilNextWrapThresholdCommentRegExp } from 'prettier-plugin-multiline-arrays';
 
 const intersectObjectsMock = jest.fn();
 
@@ -236,38 +237,51 @@ describe('dive/model/DIVEModel', () => {
     });
 
     it('should place on floor', () => {
+        model.SetModel(gltf);
+
         const com = DIVECommunication.get('id')!;
         const spyPerformAction = jest.spyOn(com, 'PerformAction');
 
         model.userData.id = 'something';
+        model.position.set(0, 4, 0);
 
-        model['_boundingBox'] = {
-            min: new Vector3(0, 1, 0),
-            max: new Vector3(1, 4, 1),
-        } as unknown as Box3;
+        // @ts-ignore
+        model['_mesh'].geometry = {
+            computeBoundingBox: jest.fn(),
+        };
+        // @ts-ignore
+        model['_mesh'].localToWorld = (vec3: Vector3) => {
+            return vec3;
+        };
+        // @ts-ignore
+        model['_mesh']['geometry'].boundingBox = {
+            min: new Vector3(0, -2, 0),
+        };
+        // @ts-ignore
+        model['_mesh'].localToWorld = () => {
+            return new Vector3(0, 2, 0);
+        };
+
+        const scene = {
+            parent: null,
+            Root: {
+                children: [
+                    model,
+                ],
+            },
+        } as unknown as DIVEScene;
+        scene.Root.parent = scene;
+        model.parent = scene.Root;
 
         expect(() => model.PlaceOnFloor()).not.toThrow();
         expect(spyPerformAction).toHaveBeenCalledWith(
             'UPDATE_OBJECT',
             expect.objectContaining({
                 position: expect.objectContaining({
-                    y: 1.5,
+                    y: 2,
                 }),
             }),
         );
-
-        // skip any action when the position did not change
-        spyPerformAction.mockClear();
-        model.position.y = 1.5;
-        expect(() => model.PlaceOnFloor()).not.toThrow();
-        expect(spyPerformAction).not.toHaveBeenCalled();
-
-        // mock that the communication is not available
-        spyPerformAction.mockClear();
-        jest.spyOn(DIVECommunication, 'get').mockReturnValueOnce(undefined);
-        model.position.y = 0;
-        expect(() => model.PlaceOnFloor()).not.toThrow();
-        expect(spyPerformAction).not.toHaveBeenCalled();
     });
 
     it('should drop it', () => {

--- a/src/primitive/Primitive.ts
+++ b/src/primitive/Primitive.ts
@@ -111,9 +111,15 @@ export class DIVEPrimitive extends DIVENode {
         const worldPos = this.getWorldPosition(this._positionWorldBuffer);
         const oldWorldPos = worldPos.clone();
 
-        // calculate the bottom center of the bounding box and set it to world posion
-        worldPos.y = (this._boundingBox.max.y - this._boundingBox.min.y) / 2;
+        // compute the bounding box 
+        this._mesh?.geometry?.computeBoundingBox();
+        const meshBB = this._mesh?.geometry?.boundingBox;
 
+        // subtract the bounding box min y axis value from the world position y value
+        if (meshBB && this._mesh) {
+            worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
+        }
+       
         // skip any action when the position did not change
         if (worldPos.y === oldWorldPos.y) return;
 

--- a/src/primitive/Primitive.ts
+++ b/src/primitive/Primitive.ts
@@ -116,10 +116,8 @@ export class DIVEPrimitive extends DIVENode {
         const meshBB = this._mesh?.geometry?.boundingBox;
 
         // subtract the bounding box min y axis value from the world position y value
-        if (meshBB && this._mesh) {
-            worldPos.y =
-                worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
-        }
+        if (!meshBB || !this._mesh) return;
+        worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
 
         // skip any action when the position did not change
         if (worldPos.y === oldWorldPos.y) return;

--- a/src/primitive/Primitive.ts
+++ b/src/primitive/Primitive.ts
@@ -111,15 +111,16 @@ export class DIVEPrimitive extends DIVENode {
         const worldPos = this.getWorldPosition(this._positionWorldBuffer);
         const oldWorldPos = worldPos.clone();
 
-        // compute the bounding box 
+        // compute the bounding box
         this._mesh?.geometry?.computeBoundingBox();
         const meshBB = this._mesh?.geometry?.boundingBox;
 
         // subtract the bounding box min y axis value from the world position y value
         if (meshBB && this._mesh) {
-            worldPos.y = worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
+            worldPos.y =
+                worldPos.y - this._mesh.localToWorld(meshBB.min.clone()).y;
         }
-       
+
         // skip any action when the position did not change
         if (worldPos.y === oldWorldPos.y) return;
 

--- a/src/primitive/__test__/Primitive.test.ts
+++ b/src/primitive/__test__/Primitive.test.ts
@@ -139,7 +139,15 @@ jest.mock('three', () => {
         Mesh: jest.fn(function () {
             this.geometry = {
                 computeBoundingBox: jest.fn(),
-                boundingBox: new Box3(),
+                boundingBox: {
+                    min: new Vector3(0, 2, 0),
+                    max: new Vector3(2, 4, 2),
+                    getCenter: jest.fn(() => {
+                        return new Vector3(0, 0, 0);
+                    }),
+                    expandByObject: jest.fn(),
+                    setFromObject: jest.fn(),
+                },
             };
             this.material = {};
             this.castShadow = true;
@@ -257,35 +265,40 @@ describe('dive/primitive/DIVEPrimitive', () => {
         const com = DIVECommunication.get('id')!;
         const spyPerformAction = jest.spyOn(com, 'PerformAction');
 
-        primitive.userData.id = 'something';
+        const size = {
+            x: 1,
+            y: 1,
+            z: 1,
+        };
 
+        primitive.userData.id = 'something';
+        primitive.position.set(0, 2, 0);
         primitive['_boundingBox'] = {
-            min: new Vector3(0, 1, 0),
-            max: new Vector3(0, 4, 0),
+            min: new Vector3(0, -2, 0),
+            setFromObject: jest.fn(),
         } as unknown as Box3;
+
+        const scene = {
+            parent: null,
+            Root: {
+                children: [
+                    primitive,
+                ],
+            },
+        } as unknown as DIVEScene;
+        scene.Root.parent = scene;
+
+        primitive.parent = scene.Root;
 
         expect(() => primitive.PlaceOnFloor()).not.toThrow();
         expect(spyPerformAction).toHaveBeenCalledWith(
             'UPDATE_OBJECT',
             expect.objectContaining({
                 position: expect.objectContaining({
-                    y: 1.5,
+                    y: 0,
                 }),
             }),
         );
-
-        // skip any action when the position did not change
-        spyPerformAction.mockClear();
-        primitive.position.y = 1.5;
-        expect(() => primitive.PlaceOnFloor()).not.toThrow();
-        expect(spyPerformAction).not.toHaveBeenCalled();
-
-        // mock that the communication is not available
-        spyPerformAction.mockClear();
-        jest.spyOn(DIVECommunication, 'get').mockReturnValueOnce(undefined);
-        primitive.position.y = 0;
-        expect(() => primitive.PlaceOnFloor()).not.toThrow();
-        expect(spyPerformAction).not.toHaveBeenCalled();
     });
 
     it('should drop it', () => {

--- a/src/primitive/__test__/Primitive.test.ts
+++ b/src/primitive/__test__/Primitive.test.ts
@@ -265,12 +265,6 @@ describe('dive/primitive/DIVEPrimitive', () => {
         const com = DIVECommunication.get('id')!;
         const spyPerformAction = jest.spyOn(com, 'PerformAction');
 
-        const size = {
-            x: 1,
-            y: 1,
-            z: 1,
-        };
-
         primitive.userData.id = 'something';
         primitive.position.set(0, 2, 0);
         primitive['_boundingBox'] = {


### PR DESCRIPTION
### 1. Why is this change necessary?
The current logic for placing scene objects in the floor is not working for all primitives / groups / models because it assumes a fixed, centered pivot point.

### 2. What does this change do, exactly?
This change aims to fix the place on floor the function so it behaves the same regardless of where the pivot point is located for a model or primitive

### 3. link to the relevant issue:
https://shopware.atlassian.net/browse/NEXT-39988
