### PR TITLE
feat: add context loss protection by limiting active dive instances.

### DIFF
--- a/src/engine/Dive.ts
+++ b/src/engine/Dive.ts
@@ -32,6 +32,12 @@ declare global {
              * Get the first instance of DIVE
              */
             get instance(): DIVE | undefined;
+            /**
+             * Maximum amount of DIVE instances that can be created. This is checked on initialization of a new instance.
+             *
+             * You can change this value to allow more instances, but be aware that this can lead to performance issues and crashes.
+             */
+            instanceLimit: number;
         };
     }
 }
@@ -41,6 +47,7 @@ window.DIVE = {
     get instance() {
         return window.DIVE.instances[0];
     },
+    instanceLimit: 8,
 };
 
 export type DIVESettings = {
@@ -113,6 +120,14 @@ export class DIVE {
             ...DIVEDefaultSettings,
             ...(settings ?? {}),
         };
+
+        // check for instance limit
+        if (window.DIVE.instances.length == window.DIVE.instanceLimit) {
+            throw new Error(
+                `DIVE instance limit exceeded! Maximum allowed instances: ${window.DIVE.instanceLimit}. Current instances: ${window.DIVE.instances.length}.`,
+            );
+        }
+
         // set up the clock to define the tick
         this._clock = new DIVEClock();
 

--- a/src/engine/__test__/Dive.test.ts
+++ b/src/engine/__test__/Dive.test.ts
@@ -225,6 +225,7 @@ vi.mock('../../components/model/Model', () => {
 
 describe('DIVE', () => {
     beforeEach(() => {
+        window.DIVE.instanceLimit = 8;
         window.DIVE.instances = [];
         console.log = vi.fn();
     });
@@ -232,6 +233,16 @@ describe('DIVE', () => {
     it('should instantiate', () => {
         const dive = new DIVE();
         expect(dive).toBeDefined();
+    });
+
+    it('should not exceed the instance limit', () => {
+        window.DIVE.instanceLimit = 1;
+        const dive1 = new DIVE();
+        expect(dive1).toBeDefined();
+
+        expect(() => new DIVE()).toThrowError(
+            /DIVE instance limit exceeded! Maximum allowed instances: 1. Current instances: 1./,
+        );
     });
 
     it('should register the main view with the clock', () => {

--- a/src/plugins/quickview/src/QuickView.ts
+++ b/src/plugins/quickview/src/QuickView.ts
@@ -24,35 +24,40 @@ export const QuickView = async (
     uri: string,
     settings?: Partial<QuickViewSettings>,
 ): Promise<QuickView> => {
-    const dive = new DIVE({ ...settings, autoStart: false });
+    try {
+        const dive = new DIVE({ ...settings, autoStart: false });
 
-    dive.mainView.camera.position.set(0, 1, 2);
+        dive.mainView.camera.position.set(0, 1, 2);
 
-    // instantiate model
-    const model = await new DIVEModel().setFromURL(uri);
-    dive.scene.root.add(model);
-    model.placeOnFloor();
+        // instantiate model
+        const model = await new DIVEModel().setFromURL(uri);
+        dive.scene.root.add(model);
+        model.placeOnFloor();
 
-    const orbitController = new OrbitController(
-        dive.mainView.camera,
-        dive.mainView.canvas,
-    );
-    dive.clock.addTicker(orbitController);
+        const orbitController = new OrbitController(
+            dive.mainView.camera,
+            dive.mainView.canvas,
+        );
+        dive.clock.addTicker(orbitController);
 
-    const quickView = Object.assign(dive, { orbitController, model });
+        const quickView = Object.assign(dive, { orbitController, model });
 
-    const originalDispose = dive.disposeAsync.bind(dive);
-    quickView.disposeAsync = async () => {
-        orbitController.dispose();
+        const originalDispose = dive.disposeAsync.bind(dive);
+        quickView.disposeAsync = async () => {
+            orbitController.dispose();
 
-        // dispose dive
-        await originalDispose();
-    };
+            // dispose dive
+            await originalDispose();
+        };
 
-    if (settings?.autoStart ?? true) {
-        await dive.startAsync();
-        orbitController.focusObject(model);
+        if (settings?.autoStart ?? true) {
+            await dive.startAsync();
+            orbitController.focusObject(model);
+        }
+
+        return quickView;
+    } catch (error) {
+        console.error('Failed to initialize QuickView:', error);
+        return Promise.reject(error);
     }
-
-    return quickView;
 };

--- a/src/plugins/quickview/src/__test__/QuickView.test.ts
+++ b/src/plugins/quickview/src/__test__/QuickView.test.ts
@@ -97,6 +97,16 @@ describe('QuickView', () => {
         expect(dive.startAsync).toHaveBeenCalledTimes(1);
     });
 
+    it('should catch errors during DIVE initialization', async () => {
+        vi.mocked(DIVE).mockImplementationOnce(() => {
+            throw new Error('DIVE initialization error');
+        });
+
+        await expect(QuickView('test_uri')).rejects.toThrow(
+            'DIVE initialization error',
+        );
+    });
+
     it('should handle QuickView with multiple instances', async () => {
         const dive1 = await QuickView('test_uri');
         const dive2 = await QuickView('test_uri');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When too many dive instances are created, old WebGLContexts are lost.

### 2. What does this change do, exactly?
This is now prohibited by introducing a dive instance limit. When you want to exceed it by creating another instance, the instancing aborts and throws an error. Default limit is set to 8 parallel instances.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.