### PR TITLE
chore: fix type errors and enforce typecheck in CI

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -95,6 +95,23 @@ jobs:
               run: yarn
             - name: Build DIVE
               run: yarn build
+    typecheck:
+        runs-on: ubuntu-latest
+        needs: install
+        steps:
+            - name: Checkout DIVE
+              uses: actions/checkout@main
+            - name: Search for cached dependencies
+              uses: actions/cache@main
+              id: yarn-cache
+              with:
+                  path: node_modules
+                  key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+            - name: Install DIVE dependencies (if cache not found)
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
+              run: yarn
+            - name: Typecheck DIVE
+              run: yarn typecheck
     check-docs:
         runs-on: ubuntu-latest
         needs: install
@@ -232,7 +249,7 @@ jobs:
     #               done
     publish-dry-run:
         runs-on: ubuntu-latest
-        needs: [unit, eslint, build, prettier-check, check-docs]
+        needs: [unit, eslint, build, prettier-check, check-docs, typecheck]
         if: github.actor != 'dependabot[bot]'
         steps:
             - name: Checkout

--- a/src/components/gizmo/__test__/Gizmo.test.ts
+++ b/src/components/gizmo/__test__/Gizmo.test.ts
@@ -76,7 +76,7 @@ describe('DIVEGizmo', () => {
     let mockObject: Object3D & DIVESelectable;
 
     beforeEach(() => {
-        mockController = new OrbitController();
+        mockController = new OrbitController(null as any, null as any);
         gizmo = new DIVEGizmo(mockController);
 
         mockObject = new Object3D() as Object3D & DIVESelectable;

--- a/src/components/gizmo/rotate/__test__/RotateGizmo.test.ts
+++ b/src/components/gizmo/rotate/__test__/RotateGizmo.test.ts
@@ -62,7 +62,7 @@ describe('DIVERotateGizmo', () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
-        mockController = new OrbitController();
+        mockController = new OrbitController(null as any, null as any);
         rotateGizmo = new DIVERotateGizmo(mockController);
 
         mockGizmo = {

--- a/src/components/gizmo/scale/__test__/ScaleGizmo.test.ts
+++ b/src/components/gizmo/scale/__test__/ScaleGizmo.test.ts
@@ -54,7 +54,7 @@ describe('DIVEScaleGizmo', () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
-        mockController = new OrbitController();
+        mockController = new OrbitController(null as any, null as any);
         scaleGizmo = new DIVEScaleGizmo(mockController);
 
         mockGizmo = {

--- a/src/components/gizmo/translate/__test__/TranslateGizmo.test.ts
+++ b/src/components/gizmo/translate/__test__/TranslateGizmo.test.ts
@@ -53,7 +53,7 @@ describe('DIVETranslateGizmo', () => {
     beforeEach(() => {
         vi.clearAllMocks();
 
-        mockController = new OrbitController();
+        mockController = new OrbitController(null as any, null as any);
         translateGizmo = new DIVETranslateGizmo(mockController);
 
         mockGizmo = {

--- a/src/engine/camera/__test__/PerspectiveCamera.test.ts
+++ b/src/engine/camera/__test__/PerspectiveCamera.test.ts
@@ -1,11 +1,11 @@
-import { DIVEPerspectiveCamera } from '../PerspectiveCamera';
-import { DIVEPerspectiveCameraDefaultSettings } from '../PerspectiveCamera';
+import { DIVEPerspectiveCamera } from '../PerspectiveCamera.ts';
+import { DIVEPerspectiveCameraDefaultSettings } from '../PerspectiveCamera.ts';
 import {
     DEFAULT_LAYER_MASK,
     HELPER_LAYER_MASK,
     PRODUCT_LAYER_MASK,
     UI_LAYER_MASK,
-} from '../../../constants/VisibilityLayerMask';
+} from '../../../constants/VisibilityLayerMask.ts';
 
 describe('dive/engine/camera/DIVEPerspectiveCamera', () => {
     it('should instantiate with default settings', () => {

--- a/src/engine/canvas/__test__/CanvasLifecycleManager.test.ts
+++ b/src/engine/canvas/__test__/CanvasLifecycleManager.test.ts
@@ -54,7 +54,7 @@ describe('DIVECanvasLifecycleManager', () => {
                 width,
                 height,
             },
-        }) as ResizeObserverEntry;
+        }) as unknown as ResizeObserverEntry;
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/src/engine/environment/__test__/Environment.test.ts
+++ b/src/engine/environment/__test__/Environment.test.ts
@@ -147,7 +147,9 @@ describe('HDREnvironment', () => {
 
     it('does not update during init when the renderer is not initialized', async () => {
         const uninitializedRenderer = new WebGPURenderer();
-        uninitializedRenderer.initialized = false;
+        (
+            uninitializedRenderer as unknown as { initialized: boolean }
+        ).initialized = false;
         const env = new DIVEEnvironment(uninitializedRenderer, scene, {
             imageUrl: 'hdr.hdr',
         });

--- a/src/error/file-type/__tests__/file-type-error.test.ts
+++ b/src/error/file-type/__tests__/file-type-error.test.ts
@@ -1,4 +1,4 @@
-import { FileTypeError } from '../file-type-error';
+import { FileTypeError } from '../file-type-error.ts';
 
 describe('FileTypeError', () => {
     it('should create a FileTypeError with message and requested file type', () => {

--- a/src/helpers/math/__test__/DIVEMath.test.ts
+++ b/src/helpers/math/__test__/DIVEMath.test.ts
@@ -1,4 +1,4 @@
-import { DIVEMath } from '../index';
+import { DIVEMath } from '../index.ts';
 
 describe('dive/math', () => {
     it('should be defined', () => {

--- a/src/helpers/math/ceil/__test__/ceilExp.test.ts
+++ b/src/helpers/math/ceil/__test__/ceilExp.test.ts
@@ -1,4 +1,4 @@
-import ceilExp from '../ceilExp';
+import ceilExp from '../ceilExp.ts';
 
 describe('dive/math/ceil/ceilExp', () => {
     it('should ceilExp', () => {

--- a/src/helpers/math/degToRad/__test__/degToRad.test.ts
+++ b/src/helpers/math/degToRad/__test__/degToRad.test.ts
@@ -1,4 +1,4 @@
-import degToRad from '../degToRad';
+import degToRad from '../degToRad.ts';
 import { MathUtils } from 'three/webgpu';
 
 vi.mock('three/webgpu', async () => {

--- a/src/helpers/math/floor/__test__/floorExp.test.ts
+++ b/src/helpers/math/floor/__test__/floorExp.test.ts
@@ -1,4 +1,4 @@
-import floorExp from '../floorExp';
+import floorExp from '../floorExp.ts';
 
 describe('dive/math/floor/floorExp', () => {
     it('should floorExp', () => {

--- a/src/helpers/math/helper/__test__/shift.test.ts
+++ b/src/helpers/math/helper/__test__/shift.test.ts
@@ -1,4 +1,4 @@
-import shift from '../shift';
+import shift from '../shift.ts';
 
 describe('dive/math/helper/shift', () => {
     it('should shift', () => {

--- a/src/helpers/math/radToDeg/__test__/radToDeg.test.ts
+++ b/src/helpers/math/radToDeg/__test__/radToDeg.test.ts
@@ -1,4 +1,4 @@
-import radToDeg from '../radToDeg';
+import radToDeg from '../radToDeg.ts';
 import { MathUtils } from 'three/webgpu';
 
 vi.mock('three/webgpu', async () => {

--- a/src/helpers/math/round/__test__/roundExp.test.ts
+++ b/src/helpers/math/round/__test__/roundExp.test.ts
@@ -1,4 +1,4 @@
-import roundExp from '../roundExp';
+import roundExp from '../roundExp.ts';
 
 describe('dive/math/round/roundExp', () => {
     it('should roundExp', () => {

--- a/src/helpers/math/signedAngleTo/__test__/signedAngleTo.test.ts
+++ b/src/helpers/math/signedAngleTo/__test__/signedAngleTo.test.ts
@@ -1,5 +1,5 @@
 import { Vector3 } from 'three/webgpu';
-import signedAngleTo from '../signedAngleTo';
+import signedAngleTo from '../signedAngleTo.ts';
 
 describe('dive/math/signedAngleTo', () => {
     it('should signedAngleTo', () => {

--- a/src/helpers/math/toFixed/__test__/toFixedExp.test.ts
+++ b/src/helpers/math/toFixed/__test__/toFixedExp.test.ts
@@ -1,4 +1,4 @@
-import toFixedExp from '../toFixedExp';
+import toFixedExp from '../toFixedExp.ts';
 
 describe('dive/math/toFixed/toFixedExp', () => {
     it('should toFixedExp', () => {

--- a/src/helpers/math/truncate/__test__/truncateExp.test.ts
+++ b/src/helpers/math/truncate/__test__/truncateExp.test.ts
@@ -1,4 +1,4 @@
-import truncateExp from '../truncateExp';
+import truncateExp from '../truncateExp.ts';
 
 describe('dive/math/truncate/truncateExp', () => {
     it('should truncateExp', () => {

--- a/src/interfaces/__test__/Movable.test.ts
+++ b/src/interfaces/__test__/Movable.test.ts
@@ -1,4 +1,4 @@
-import { DIVEMovable } from '../Movable';
+import { DIVEMovable } from '../Movable.ts';
 
 describe('DIVEMovable', () => {
     it('should have isMovable property set to true', () => {

--- a/src/interfaces/__test__/Selectable.test.ts
+++ b/src/interfaces/__test__/Selectable.test.ts
@@ -1,4 +1,4 @@
-import { DIVESelectable } from '../Selectable';
+import { DIVESelectable } from '../Selectable.ts';
 
 describe('DIVESelectable', () => {
     it('should have isSelectable property set to true', () => {

--- a/src/plugins/animation/src/animator/__test__/TargetAnimator.test.ts
+++ b/src/plugins/animation/src/animator/__test__/TargetAnimator.test.ts
@@ -229,11 +229,11 @@ describe('TargetAnimator', () => {
     describe('Update', () => {
         it('should not throw on update', () => {
             animator.play();
-            expect(() => animator.update(0.016)).not.toThrow();
+            expect(() => animator.update()).not.toThrow();
         });
 
         it('should skip group update when idle', () => {
-            expect(() => animator.update(0.016)).not.toThrow();
+            expect(() => animator.update()).not.toThrow();
         });
     });
 

--- a/src/plugins/assetexporter/src/AssetExporter.ts
+++ b/src/plugins/assetexporter/src/AssetExporter.ts
@@ -53,7 +53,12 @@ export class AssetExporter {
                 return this._exportGltf(object, options);
             }
             case 'usdz': {
-                return this._exportUsdz(object, options);
+                // `options` is FileTypeToExporterOptions[T]; TS can't correlate it
+                // with the runtime `type` switch, so narrow to the usdz variant here.
+                return this._exportUsdz(
+                    object,
+                    options as USDZExporterOptions | undefined,
+                );
             }
             default:
                 throw new FileTypeError(`Unsupported file type: ${type}`, type);

--- a/src/plugins/assetloader/src/loader/__test__/AssetLoader.test.ts
+++ b/src/plugins/assetloader/src/loader/__test__/AssetLoader.test.ts
@@ -93,7 +93,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model.glb');
 
@@ -117,7 +117,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model.glb');
 
@@ -138,7 +138,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model.glb');
 
@@ -177,7 +177,9 @@ describe('AssetLoader', () => {
             const mockArrayBuffer = new ArrayBuffer(1024);
             const mockResult = new Group();
             mockChunk.load.mockResolvedValue(mockArrayBuffer);
-            mockParseAsyncGLTF.mockResolvedValue({ scene: mockResult } as GLTF);
+            mockParseAsyncGLTF.mockResolvedValue({
+                scene: mockResult,
+            } as unknown as GLTF);
 
             await loader.load('model.GLB');
 
@@ -192,7 +194,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model-without-extension', 'glb');
 
@@ -218,7 +220,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model-without-extension');
 
@@ -241,7 +243,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load('model-without-extension');
 
@@ -343,7 +345,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
             mockChunk.load.mockResolvedValue(mockArrayBuffer);
 
             const result = await loader.load('model.glb');
@@ -363,7 +365,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
             mockChunk.load.mockResolvedValue(mockArrayBuffer);
 
             const result = await loader.load('model.gltf');
@@ -443,7 +445,7 @@ describe('AssetLoader', () => {
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: mockScene,
                 animations: [],
-            } as GLTF);
+            } as unknown as GLTF);
 
             const result = await loader.load(uri);
 
@@ -494,7 +496,7 @@ describe('AssetLoader', () => {
             mockChunk.load.mockResolvedValue(mockArrayBuffer);
             mockParseAsyncGLTF.mockResolvedValue({
                 scene: new Group(),
-            } as GLTF);
+            } as unknown as GLTF);
             mockParseUSD.mockResolvedValue(new Group());
             mockStepParseAsync.mockResolvedValue(new Group());
         });

--- a/src/plugins/mediacreator/src/__test__/MediaCreator.test.ts
+++ b/src/plugins/mediacreator/src/__test__/MediaCreator.test.ts
@@ -251,15 +251,12 @@ describe('MediaCreator', () => {
             },
         });
 
-        expect(mockOrbitController.object.onResize).toHaveBeenNthCalledWith(
-            1,
-            16,
-            9,
-        );
-        expect(mockOrbitController.object.onResize).toHaveBeenLastCalledWith(
-            16,
-            9,
-        );
+        expect(
+            (mockOrbitController.object as any).onResize,
+        ).toHaveBeenNthCalledWith(1, 16, 9);
+        expect(
+            (mockOrbitController.object as any).onResize,
+        ).toHaveBeenLastCalledWith(16, 9);
     });
 
     it('should fall back to the renderer canvas size when no resolution is provided', async () => {

--- a/src/plugins/state/src/actions/camera/__test__/setcameralayer.test.ts
+++ b/src/plugins/state/src/actions/camera/__test__/setcameralayer.test.ts
@@ -4,9 +4,10 @@ import { OrbitController } from '@shopware-ag/dive/orbitcontroller';
 describe('SetCameraLayerAction', () => {
     it('should set camera layer', async () => {
         // Mock dependencies
+        const setCameraLayer = vi.fn();
         const mockController = {
             object: {
-                setCameraLayer: vi.fn(),
+                setCameraLayer,
             },
         } as unknown as OrbitController;
 
@@ -21,8 +22,6 @@ describe('SetCameraLayerAction', () => {
         action.execute();
 
         // Verify results
-        expect(mockController.object.setCameraLayer).toHaveBeenCalledWith(
-            'LIVE',
-        );
+        expect(setCameraLayer).toHaveBeenCalledWith('LIVE');
     });
 });

--- a/src/plugins/toolbox/src/transform/__test__/TransformTool.test.ts
+++ b/src/plugins/toolbox/src/transform/__test__/TransformTool.test.ts
@@ -818,7 +818,7 @@ describe('TransformTool', () => {
 
     describe('gizmo initialization', () => {
         it('should call traverse on gizmo during initialization', () => {
-            expect(transformTool.gizmo.traverse).toHaveBeenCalled();
+            expect((transformTool.gizmo as any).traverse).toHaveBeenCalled();
         });
 
         it('should set colors on mesh children during traverse', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Removing the bogus `tsc@2.0.4` dep (in #217) makes `yarn typecheck` functional again — which surfaced 36 pre-existing, unchecked type errors. Nothing enforced type safety in CI.

### 2. What does this change do, exactly?

- Fixes all 36 type errors: 16 missing `.ts` import extensions, GLTF/ResizeObserver mock casts, test constructor/arity mismatches, and one real source narrowing in `AssetExporter` (usdz options).
- Adds a `typecheck` job to the PR CI workflow.

### 3. Describe each step to reproduce the issue or behaviour.

Run `yarn typecheck`: 36 errors before, 0 after. `yarn unit` stays green (1542 passed).

### 4. Please link to the relevant issues (if any).

Stacked on #217 (depends on the `tsc` removal); retarget to `trunk` once #217 is merged.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.