### PR TITLE
fix: change environment saving in HDR Environment.

### DIFF
--- a/src/engine/environment/Environment.ts
+++ b/src/engine/environment/Environment.ts
@@ -82,7 +82,11 @@ export const DIVEEnvironmentDefaultSettings: DIVEEnvironmentSettings = {
  * generating a PMREM for scene.environment.
  */
 export class DIVEEnvironment {
-    private originalBackground: typeof Scene.prototype.background;
+    // The background to put back once the HDR is no longer used as one.
+    private originalBackground: typeof Scene.prototype.background = null;
+
+    // The background this environment last put on the scene itself.
+    private installedBackground: typeof Scene.prototype.background = null;
 
     private _webgpurenderer: WebGPURenderer;
     private scene: Scene;
@@ -104,7 +108,6 @@ export class DIVEEnvironment {
     ) {
         this._webgpurenderer = renderer;
         this.scene = scene;
-        this.originalBackground = this.scene.background;
 
         this.pmrem = new PMREMGenerator(renderer);
         this.options = {
@@ -149,9 +152,27 @@ export class DIVEEnvironment {
         this.clearEnvironment();
     }
 
+    /**
+     * Whether `scene.background` is still the one this environment installed.
+     *
+     * A foreign value means something else has changed the background in the
+     * meantime, which makes it the value to restore instead.
+     */
+    private ownsSceneBackground(): boolean {
+        return (
+            this.installedBackground !== null &&
+            this.scene.background === this.installedBackground
+        );
+    }
+
     private clearEnvironment(): void {
         this.scene.environment = null;
-        this.scene.background = this.originalBackground;
+
+        // never revert a background that was not put there by this environment
+        if (this.ownsSceneBackground()) {
+            this.scene.background = this.originalBackground;
+            this.installedBackground = null;
+        }
 
         if (this.currentEnvRT) {
             this.currentEnvRT.texture.dispose();
@@ -177,6 +198,12 @@ export class DIVEEnvironment {
      */
     public update(): void {
         if (!this._webgpurenderer.initialized) return;
+
+        // a background we did not install belongs to someone else and is the one
+        // to restore, so it has to be picked up before it gets overwritten
+        if (!this.ownsSceneBackground()) {
+            this.originalBackground = this.scene.background;
+        }
 
         if (!this.sourceImage) {
             this.clearEnvironment();
@@ -234,9 +261,11 @@ export class DIVEEnvironment {
         // keep unfiltered capture as background (matches HDRLoader brightness)
         if (this.options.useAsBackground) {
             this.scene.background = cubeRT.texture;
+            this.installedBackground = cubeRT.texture;
             this.currentBackgroundCube = cubeRT;
         } else {
             this.scene.background = this.originalBackground;
+            this.installedBackground = null;
             // We created a cubeRT but are not using it as background.
             // We should dispose it if we don't store it in currentBackgroundCube.
             // But we used it for PMREM. Can we dispose it now?

--- a/src/engine/environment/__test__/Environment.test.ts
+++ b/src/engine/environment/__test__/Environment.test.ts
@@ -299,6 +299,164 @@ describe('HDREnvironment', () => {
         expect(scene.background).not.toBe(originalBg);
     });
 
+    it('does not capture the scene background in the constructor', () => {
+        scene.background = new Color(0x654321);
+
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+        });
+
+        expect((env as any).originalBackground).toBeNull();
+        expect((env as any).installedBackground).toBeNull();
+    });
+
+    it('captures a background that is set after construction', async () => {
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+
+        // the scene background is commonly set while the HDR is still loading
+        const originalBg = new Color(0x123456);
+        scene.background = originalBg;
+
+        await env.initAsync();
+
+        expect((env as any).originalBackground).toBe(originalBg);
+        expect(scene.background).not.toBe(originalBg);
+
+        env.setUseAsBackground(false);
+
+        expect(scene.background).toBe(originalBg);
+    });
+
+    it('does not mistake its own HDR background for the original one', async () => {
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+        const originalBg = new Color(0xff00ff);
+        scene.background = originalBg;
+
+        await env.initAsync();
+
+        // the HDR cube is the scene background now, and re-capturing it would
+        // make the original background unrecoverable
+        env.update();
+        env.setRotationY(1.5);
+
+        expect((env as any).originalBackground).toBe(originalBg);
+
+        env.setUseAsBackground(false);
+
+        expect(scene.background).toBe(originalBg);
+    });
+
+    it('restores the latest foreign background, not the first one', async () => {
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+        scene.background = new Color(0x111111);
+
+        await env.initAsync();
+
+        // the background is changed while the HDR is the one on the scene
+        const latestBg = new Color(0x222222);
+        scene.background = latestBg;
+
+        env.setRotationY(0.75);
+
+        expect((env as any).originalBackground).toBe(latestBg);
+
+        env.setUseAsBackground(false);
+
+        expect(scene.background).toBe(latestBg);
+    });
+
+    it('restores a color that was set between two useAsBackground toggles', async () => {
+        const first = new Color(0x0000ff);
+        scene.background = first;
+
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+
+        await env.initAsync();
+        expect(scene.background).not.toBe(first);
+
+        env.setUseAsBackground(false);
+        expect(scene.background).toBe(first);
+
+        // the color is changed while the HDR is not used as background
+        const red = new Color(0xff0000);
+        scene.background = red;
+
+        env.setUseAsBackground(true);
+        env.setUseAsBackground(false);
+
+        expect(scene.background).toBe(red);
+        expect(scene.background).not.toBe(first);
+    });
+
+    it('re-captures the background on every update while unused as background', async () => {
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: false,
+        });
+        scene.background = new Color(0x333333);
+
+        await env.initAsync();
+
+        const latestBg = new Color(0x444444);
+        scene.background = latestBg;
+
+        env.setRotationY(0.5);
+
+        expect((env as any).originalBackground).toBe(latestBg);
+        expect(scene.background).toBe(latestBg);
+    });
+
+    it('keeps a foreign background when the source image is missing', async () => {
+        const originalBg = new Color(0xabcdef);
+        scene.background = originalBg;
+
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+
+        // the HDR is still in flight, so update() only clears the environment
+        env.update();
+
+        expect(scene.environment).toBeNull();
+        expect(scene.background).toBe(originalBg);
+
+        await env.initAsync();
+        env.setUseAsBackground(false);
+
+        expect(scene.background).toBe(originalBg);
+    });
+
+    it('keeps a foreign background on dispose', async () => {
+        const env = new DIVEEnvironment(renderer, scene, {
+            imageUrl: 'hdr.hdr',
+            useAsBackground: true,
+        });
+        scene.background = new Color(0x555555);
+
+        await env.initAsync();
+
+        const latestBg = new Color(0x666666);
+        scene.background = latestBg;
+
+        env.dispose();
+
+        expect(scene.environment).toBeNull();
+        expect(scene.background).toBe(latestBg);
+    });
+
     it('updates renderer and regenerates PMREM', async () => {
         const env = new DIVEEnvironment(renderer, scene, {
             imageUrl: 'hdr.hdr',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The current implementation leads to errors when instantiating dive (without auto-starting), then changing the scene background, then starting render process. 

This happens in Shopware Scene Editor atm: We instantiate dive, load the scene resources, apply them in dive and then start rendering.

### 2. What does this change do, exactly?
Extend the background management in the HDR Environment so that it always restores the correct scene background.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.