### PR TITLE
feat: add own SpriteText class. remove three-spritetext dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "dependencies": {
         "three": "^0.185.1",
         "@tweenjs/tween.js": "^25.0.0",
-        "three-spritetext": "^1.8.2",
         "lodash": "^4.18.1",
         "occt-import-js": "^0.0.23"
     },

--- a/scripts/build/vite/vite-plugin-exports.ts
+++ b/scripts/build/vite/vite-plugin-exports.ts
@@ -10,11 +10,7 @@ interface pluginRegistration {
     buildPath: string; // Path in the build output
 }
 
-const externalDependencies = [
-    /^three(?:\/.*)?$/,
-    '@tweenjs/tween.js',
-    'three-spritetext',
-];
+const externalDependencies = [/^three(?:\/.*)?$/, '@tweenjs/tween.js'];
 
 // Function to update package.json exports
 function updatePackageJsonExports(registrations: pluginRegistration[]): void {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,4 +7,5 @@ export * from './model/Model.ts';
 export * from './node/Node.ts';
 export * from './primitive/Primitive.ts';
 export * from './root/Root.ts';
+export * from './spritetext/SpriteText.ts';
 export * from './boundingbox/BoundingBox.ts';

--- a/src/components/spritetext/SpriteText.ts
+++ b/src/components/spritetext/SpriteText.ts
@@ -1,0 +1,109 @@
+import {
+    CanvasTexture,
+    Color,
+    type ColorRepresentation,
+    SRGBColorSpace,
+    Sprite,
+    SpriteMaterial,
+} from 'three/webgpu';
+
+/** Canvas height of one rasterized line in pixels. Defines the label's resolution. */
+const FONT_SIZE = 90;
+
+/** Font the label is rasterized with. */
+const FONT = `normal ${FONT_SIZE}px Arial`;
+
+/**
+ * A camera facing text label.
+ *
+ * The text is rasterized to a canvas and applied to a sprite, so the label always
+ * faces the camera while keeping a constant height in world units.
+ *
+ * @module
+ */
+export class DIVESpriteText extends Sprite {
+    readonly isDIVESpriteText: true = true;
+
+    private _text: string;
+    private _textHeight: number;
+    private _color: Color;
+
+    private _canvas: HTMLCanvasElement;
+    private _texture: CanvasTexture;
+
+    constructor(
+        text: string,
+        textHeight: number = 1,
+        color: ColorRepresentation = 0xffffff,
+    ) {
+        super(new SpriteMaterial());
+
+        this.name = 'DIVESpriteText';
+
+        this._text = text;
+        this._textHeight = textHeight;
+        this._color = new Color(color);
+
+        this._canvas = document.createElement('canvas');
+        this._texture = new CanvasTexture(this._canvas);
+        this._texture.colorSpace = SRGBColorSpace;
+
+        (this.material as SpriteMaterial).map = this._texture;
+
+        this._draw();
+    }
+
+    public setText(text: string): void {
+        this._text = text;
+        this._draw();
+    }
+
+    public setTextHeight(textHeight: number): void {
+        this._textHeight = textHeight;
+        this._draw();
+    }
+
+    public setColor(color: ColorRepresentation): void {
+        this._color = new Color(color);
+        this._draw();
+    }
+
+    public dispose(): void {
+        this._texture.dispose();
+        (this.material as SpriteMaterial).dispose();
+    }
+
+    /**
+     * Rasterizes the text to the canvas and scales the sprite to the resulting
+     * aspect ratio, so the label's height matches its text height in world units.
+     */
+    private _draw(): void {
+        const context = this._canvas.getContext('2d');
+
+        // no 2D context means there is nothing to rasterize to (e.g. in jsdom)
+        if (context === null) return;
+
+        context.font = FONT;
+        const width = Math.max(
+            1,
+            Math.ceil(context.measureText(this._text).width),
+        );
+
+        this._canvas.width = width;
+        this._canvas.height = FONT_SIZE;
+
+        // resizing the canvas resets the context, so the font has to be set again
+        context.font = FONT;
+        context.fillStyle = `#${this._color.getHexString()}`;
+        context.textBaseline = 'bottom';
+        context.fillText(this._text, 0, FONT_SIZE);
+
+        this._texture.needsUpdate = true;
+
+        this.scale.set(
+            (this._textHeight * width) / FONT_SIZE,
+            this._textHeight,
+            1,
+        );
+    }
+}

--- a/src/components/spritetext/__test__/SpriteText.test.ts
+++ b/src/components/spritetext/__test__/SpriteText.test.ts
@@ -1,0 +1,122 @@
+import { SpriteMaterial } from 'three/webgpu';
+import { DIVESpriteText } from '../SpriteText.ts';
+
+/** Rasterized width of a single character in the mocked 2D context. */
+const CHAR_WIDTH = 50;
+const FONT_SIZE = 90;
+
+const createContext = () =>
+    ({
+        font: '',
+        fillStyle: '',
+        textBaseline: '',
+        measureText: vi.fn((text: string) => ({
+            width: text.length * CHAR_WIDTH,
+        })),
+        fillText: vi.fn(),
+    }) as unknown as CanvasRenderingContext2D;
+
+let context: CanvasRenderingContext2D;
+
+beforeEach(() => {
+    context = createContext();
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+        context,
+    );
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('DIVESpriteText', () => {
+    it('should construct with a canvas texture', () => {
+        const sprite = new DIVESpriteText('X', 0.2, '#c20017');
+
+        expect(sprite.isDIVESpriteText).toBe(true);
+        expect(sprite.name).toBe('DIVESpriteText');
+
+        const map = (sprite.material as SpriteMaterial).map;
+        expect(map).not.toBeNull();
+        expect(map!.image).toBeInstanceOf(HTMLCanvasElement);
+    });
+
+    it('should rasterize the text in the given color', () => {
+        new DIVESpriteText('X', 0.2, '#c20017');
+
+        expect(context.fillStyle).toBe('#c20017');
+        expect(context.textBaseline).toBe('bottom');
+        expect(context.fillText).toHaveBeenCalledWith('X', 0, FONT_SIZE);
+    });
+
+    it('should scale the sprite to the text height and aspect ratio', () => {
+        const sprite = new DIVESpriteText('XY', 0.2, '#c20017');
+
+        expect(sprite.scale.x).toBeCloseTo((0.2 * 2 * CHAR_WIDTH) / FONT_SIZE);
+        expect(sprite.scale.y).toBeCloseTo(0.2);
+        expect(sprite.scale.z).toBe(1);
+    });
+
+    it('should default to a text height of 1 and white', () => {
+        const sprite = new DIVESpriteText('X');
+
+        expect(sprite.scale.y).toBe(1);
+        expect(context.fillStyle).toBe('#ffffff');
+    });
+
+    it('should keep a minimum canvas width for empty text', () => {
+        const sprite = new DIVESpriteText('', 0.2);
+
+        const map = (sprite.material as SpriteMaterial).map;
+        expect((map!.image as HTMLCanvasElement).width).toBe(1);
+        expect(sprite.scale.x).toBeCloseTo(0.2 / FONT_SIZE);
+    });
+
+    it('should redraw when the text changes', () => {
+        const sprite = new DIVESpriteText('X', 0.2);
+
+        sprite.setText('XYZ');
+
+        expect(context.fillText).toHaveBeenLastCalledWith('XYZ', 0, FONT_SIZE);
+        expect(sprite.scale.x).toBeCloseTo((0.2 * 3 * CHAR_WIDTH) / FONT_SIZE);
+    });
+
+    it('should redraw when the text height changes', () => {
+        const sprite = new DIVESpriteText('X', 0.2);
+
+        sprite.setTextHeight(0.5);
+
+        expect(sprite.scale.y).toBeCloseTo(0.5);
+        expect(sprite.scale.x).toBeCloseTo((0.5 * CHAR_WIDTH) / FONT_SIZE);
+    });
+
+    it('should redraw when the color changes', () => {
+        const sprite = new DIVESpriteText('X', 0.2, '#c20017');
+
+        sprite.setColor('#00ab26');
+
+        expect(context.fillStyle).toBe('#00ab26');
+    });
+
+    it('should dispose the texture and the material', () => {
+        const sprite = new DIVESpriteText('X', 0.2);
+        const material = sprite.material as SpriteMaterial;
+        const textureDispose = vi.spyOn(material.map!, 'dispose');
+        const materialDispose = vi.spyOn(material, 'dispose');
+
+        sprite.dispose();
+
+        expect(textureDispose).toHaveBeenCalled();
+        expect(materialDispose).toHaveBeenCalled();
+    });
+
+    it('should not throw without a 2D context', () => {
+        vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+            null,
+        );
+
+        const sprite = new DIVESpriteText('X', 0.2);
+
+        expect(sprite.scale.y).toBe(1);
+    });
+});

--- a/src/plugins/orientationdisplay/src/__test__/OrientationDisplay.test.ts
+++ b/src/plugins/orientationdisplay/src/__test__/OrientationDisplay.test.ts
@@ -7,23 +7,8 @@ import {
     DIVEPerspectiveCamera,
 } from '@shopware-ag/dive';
 
-vi.mock('three-spritetext', async () => {
-    const { Object3D } = await vi.importActual<typeof import('three')>('three');
-
-    class MockSpriteText extends Object3D {
-        constructor(
-            _text: string,
-            _textHeight?: number,
-            _color?: string | number,
-        ) {
-            super();
-        }
-    }
-
-    return {
-        default: MockSpriteText,
-    };
-});
+// jsdom has no 2D canvas context, so the axes labels cannot rasterize their text
+vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
 
 const mockScene = {
     add: vi.fn(),

--- a/src/plugins/orientationdisplay/src/axes/Axes.ts
+++ b/src/plugins/orientationdisplay/src/axes/Axes.ts
@@ -6,9 +6,9 @@ import {
     AxesColorRed,
     AxesColorRedLetter,
     COORDINATE_LAYER_MASK,
+    DIVESpriteText,
 } from '@shopware-ag/dive';
 import { AxesHelper, Color, Material, Matrix4, Object3D } from 'three/webgpu';
-import SpriteText from 'three-spritetext';
 
 export class OrientationDisplayAxes extends Object3D {
     private _axesHelper: AxesHelper;
@@ -27,9 +27,9 @@ export class OrientationDisplayAxes extends Object3D {
             new Color(AxesColorBlue),
         );
 
-        const x = new SpriteText('X', 0.2, AxesColorRedLetter);
-        const y = new SpriteText('Y', 0.2, AxesColorGreenLetter);
-        const z = new SpriteText('Z', 0.2, AxesColorBlueLetter);
+        const x = new DIVESpriteText('X', 0.2, AxesColorRedLetter);
+        const y = new DIVESpriteText('Y', 0.2, AxesColorGreenLetter);
+        const z = new DIVESpriteText('Z', 0.2, AxesColorBlueLetter);
         x.layers.mask = COORDINATE_LAYER_MASK;
         y.layers.mask = COORDINATE_LAYER_MASK;
         z.layers.mask = COORDINATE_LAYER_MASK;

--- a/src/plugins/orientationdisplay/src/axes/__test__/Axes.test.ts
+++ b/src/plugins/orientationdisplay/src/axes/__test__/Axes.test.ts
@@ -1,18 +1,8 @@
 import { Matrix4 } from 'three/webgpu';
 import { OrientationDisplayAxes } from '../Axes.ts';
 
-vi.mock('three-spritetext', async () => {
-    const actual =
-        await vi.importActual<typeof import('three/webgpu')>('three/webgpu');
-
-    return {
-        default: vi.fn((text: string, textHeight: number, color: unknown) =>
-            Object.assign(new actual.Object3D(), {
-                userData: { text, textHeight, color },
-            }),
-        ),
-    };
-});
+// jsdom has no 2D canvas context, so the axes labels cannot rasterize their text
+vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null);
 
 describe('OrientationDisplayAxes', () => {
     it('should construct without errors', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,11 +3436,6 @@ test-exclude@^7.0.1:
     glob "^10.4.1"
     minimatch "^9.0.4"
 
-three-spritetext@^1.8.2:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/three-spritetext/-/three-spritetext-1.10.0.tgz#479717cbf7ea64ee2e5879952bb5e15f608bf13d"
-  integrity sha512-t08iP1FCU1lQh8T5MmCpdijKgas8GDHJE0LqMGBuVu3xqMMpFnEZhTlih7FlxLPQizHIGoumUSpfOlY1GO/Tgg==
-
 three@^0.185.1:
   version "0.185.1"
   resolved "https://registry.yarnpkg.com/three/-/three-0.185.1.tgz#63e9e241a17b101e211965121a017b4b4d8054ae"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `three-spritetext` dependency loads it's own three.js instance. This leads to version problems, since the `three-spritetext` package does not run on a webgpu-supporting three.js version. 

### 2. What does this change do, exactly?
Removes the `three-spritetext` dependency and introduces a custom SpriteText class, that replaces the package's functionality.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.